### PR TITLE
Fix OpenSearch Prod Server Errors

### DIFF
--- a/gateway/compose.production.yaml
+++ b/gateway/compose.production.yaml
@@ -35,11 +35,11 @@ services:
             opensearch:
                 condition: service_healthy
             postgres:
-                condition: service_healthy
+                condition: service_started
             redis:
-                condition: service_healthy
+                condition: service_started
             minio:
-                condition: service_healthy
+                condition: service_started
         volumes:
             - source: sds-gateway-prod-app-media
               target: /app/sds_gateway/media
@@ -105,11 +105,6 @@ services:
         command: server /files --console-address ":9001"
         networks:
             - sds-gateway-prod-minio-net
-        healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-            interval: 30s
-            timeout: 10s
-            retries: 3
 
     opensearch:
         # used for indexing and searching documents
@@ -155,11 +150,6 @@ services:
             - ./.envs/production/postgres.env
         networks:
             - sds-gateway-prod-minio-net
-        healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U postgres"]
-            interval: 10s
-            timeout: 5s
-            retries: 5
 
     redis:
         # used as caching layer for the gateway app
@@ -167,11 +157,6 @@ services:
         container_name: sds-gateway-prod-redis
         volumes:
             - sds-gateway-prod-redis-data:/data
-        healthcheck:
-            test: ["CMD", "redis-cli", "ping"]
-            interval: 10s
-            timeout: 5s
-            retries: 3
 
     # ===================
     # production services

--- a/gateway/compose.production.yaml
+++ b/gateway/compose.production.yaml
@@ -24,7 +24,6 @@ networks:
         external: true
 
 services:
-
     sds-gateway-prod-app:
         build:
             context: .
@@ -33,9 +32,14 @@ services:
         container_name: sds-gateway-prod-app
         tty: true
         depends_on:
-            - postgres
-            - redis
-            - minio
+            opensearch:
+                condition: service_healthy
+            postgres:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+            minio:
+                condition: service_healthy
         volumes:
             - source: sds-gateway-prod-app-media
               target: /app/sds_gateway/media
@@ -49,6 +53,10 @@ services:
               read_only: false
               bind:
                 selinux: z
+            - source: ./opensearch/data/certs
+              target: /app/opensearch/data/certs
+              type: bind
+              read_only: true
         env_file:
             - ./.envs/production/django.env
             - ./.envs/production/minio.env
@@ -97,6 +105,11 @@ services:
         command: server /files --console-address ":9001"
         networks:
             - sds-gateway-prod-minio-net
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
 
     opensearch:
         # used for indexing and searching documents
@@ -122,6 +135,11 @@ services:
             - "19600:9600"
         networks:
             - sds-gateway-prod-opensearch-net
+        healthcheck:
+            test: ["CMD-SHELL", "curl -k -u admin:admin https://localhost:9200/_cluster/health?pretty | grep -q '\"status\" : \"green\"\\|\"status\" : \"yellow\"'"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
 
     postgres:
         # main database for the gateway app
@@ -137,6 +155,11 @@ services:
             - ./.envs/production/postgres.env
         networks:
             - sds-gateway-prod-minio-net
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
 
     redis:
         # used as caching layer for the gateway app
@@ -144,6 +167,11 @@ services:
         container_name: sds-gateway-prod-redis
         volumes:
             - sds-gateway-prod-redis-data:/data
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 10s
+            timeout: 5s
+            retries: 3
 
     # ===================
     # production services

--- a/gateway/compose/production/django/Dockerfile
+++ b/gateway/compose/production/django/Dockerfile
@@ -96,10 +96,10 @@ RUN chmod +x /entrypoint
 COPY --chown=django:django ./compose/production/django/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
+
 COPY --chown=django:django ./compose/production/django/celery/worker/start /start-celeryworker
 RUN sed -i 's/\r$//g' /start-celeryworker
 RUN chmod +x /start-celeryworker
-
 
 COPY --chown=django:django ./compose/production/django/celery/beat/start /start-celerybeat
 RUN sed -i 's/\r$//g' /start-celerybeat

--- a/gateway/sds_gateway/api_methods/utils/opensearch_client.py
+++ b/gateway/sds_gateway/api_methods/utils/opensearch_client.py
@@ -1,16 +1,19 @@
 from django.conf import settings
 from opensearchpy import OpenSearch
-from opensearchpy.connection.http_urllib3 import Urllib3HttpConnection
+from opensearchpy import RequestsHttpConnection
+from requests.auth import HTTPBasicAuth
 
 
 def get_opensearch_client():
     return OpenSearch(
         hosts=[{"host": settings.OPENSEARCH_HOST, "port": settings.OPENSEARCH_PORT}],
-        http_auth=(settings.OPENSEARCH_USER, settings.OPENSEARCH_PASSWORD),
+        http_auth=HTTPBasicAuth(
+            settings.OPENSEARCH_USER,
+            settings.OPENSEARCH_PASSWORD,
+        ),
         use_ssl=settings.OPENSEARCH_USE_SSL,
         verify_certs=settings.OPENSEARCH_VERIFY_CERTS,
-        ssl_assert_hostname=False,
         ssl_show_warn=False,
-        connection_class=Urllib3HttpConnection,
+        connection_class=RequestsHttpConnection,
         ca_certs=settings.OPENSEARCH_CA_CERTS,
     )

--- a/gateway/sds_gateway/api_methods/utils/opensearch_client.py
+++ b/gateway/sds_gateway/api_methods/utils/opensearch_client.py
@@ -4,27 +4,13 @@ from opensearchpy.connection.http_urllib3 import Urllib3HttpConnection
 
 
 def get_opensearch_client():
-    """Get an OpenSearch client with proper SSL configuration.
-
-    The client is configured based on Django settings, with proper SSL handling
-    for both development and production environments.
-    """
-    client_kwargs = {
-        "hosts": [{"host": settings.OPENSEARCH_HOST, "port": settings.OPENSEARCH_PORT}],
-        "http_auth": (settings.OPENSEARCH_USER, settings.OPENSEARCH_PASSWORD),
-        "use_ssl": settings.OPENSEARCH_USE_SSL,
-        "verify_certs": settings.OPENSEARCH_VERIFY_CERTS,
-        "connection_class": Urllib3HttpConnection,
-    }
-
-    # Only add SSL-specific settings if SSL is enabled
-    if settings.OPENSEARCH_USE_SSL:
-        client_kwargs.update(
-            {
-                "ssl_assert_hostname": True,
-                "ssl_show_warn": True,
-                "ca_certs": settings.OPENSEARCH_CA_CERTS,
-            },
-        )
-
-    return OpenSearch(**client_kwargs)
+    return OpenSearch(
+        hosts=[{"host": settings.OPENSEARCH_HOST, "port": settings.OPENSEARCH_PORT}],
+        http_auth=(settings.OPENSEARCH_USER, settings.OPENSEARCH_PASSWORD),
+        use_ssl=settings.OPENSEARCH_USE_SSL,
+        verify_certs=settings.OPENSEARCH_VERIFY_CERTS,
+        ssl_assert_hostname=False,
+        ssl_show_warn=False,
+        connection_class=Urllib3HttpConnection,
+        ca_certs=settings.OPENSEARCH_CA_CERTS,
+    )

--- a/gateway/sds_gateway/api_methods/utils/opensearch_client.py
+++ b/gateway/sds_gateway/api_methods/utils/opensearch_client.py
@@ -1,19 +1,16 @@
 from django.conf import settings
 from opensearchpy import OpenSearch
-from opensearchpy import RequestsHttpConnection
-from requests.auth import HTTPBasicAuth
+from opensearchpy.connection.http_urllib3 import Urllib3HttpConnection
 
 
 def get_opensearch_client():
     return OpenSearch(
         hosts=[{"host": settings.OPENSEARCH_HOST, "port": settings.OPENSEARCH_PORT}],
-        http_auth=HTTPBasicAuth(
-            settings.OPENSEARCH_USER,
-            settings.OPENSEARCH_PASSWORD,
-        ),
+        http_auth=(settings.OPENSEARCH_USER, settings.OPENSEARCH_PASSWORD),
         use_ssl=settings.OPENSEARCH_USE_SSL,
         verify_certs=settings.OPENSEARCH_VERIFY_CERTS,
+        ssl_assert_hostname=False,
         ssl_show_warn=False,
-        connection_class=RequestsHttpConnection,
+        connection_class=Urllib3HttpConnection,
         ca_certs=settings.OPENSEARCH_CA_CERTS,
     )

--- a/gateway/sds_gateway/api_methods/utils/opensearch_client.py
+++ b/gateway/sds_gateway/api_methods/utils/opensearch_client.py
@@ -4,13 +4,27 @@ from opensearchpy.connection.http_urllib3 import Urllib3HttpConnection
 
 
 def get_opensearch_client():
-    return OpenSearch(
-        hosts=[{"host": settings.OPENSEARCH_HOST, "port": settings.OPENSEARCH_PORT}],
-        http_auth=(settings.OPENSEARCH_USER, settings.OPENSEARCH_PASSWORD),
-        use_ssl=settings.OPENSEARCH_USE_SSL,
-        verify_certs=settings.OPENSEARCH_VERIFY_CERTS,
-        ssl_assert_hostname=False,
-        ssl_show_warn=False,
-        connection_class=Urllib3HttpConnection,
-        ca_certs=settings.OPENSEARCH_CA_CERTS,
-    )
+    """Get an OpenSearch client with proper SSL configuration.
+
+    The client is configured based on Django settings, with proper SSL handling
+    for both development and production environments.
+    """
+    client_kwargs = {
+        "hosts": [{"host": settings.OPENSEARCH_HOST, "port": settings.OPENSEARCH_PORT}],
+        "http_auth": (settings.OPENSEARCH_USER, settings.OPENSEARCH_PASSWORD),
+        "use_ssl": settings.OPENSEARCH_USE_SSL,
+        "verify_certs": settings.OPENSEARCH_VERIFY_CERTS,
+        "connection_class": Urllib3HttpConnection,
+    }
+
+    # Only add SSL-specific settings if SSL is enabled
+    if settings.OPENSEARCH_USE_SSL:
+        client_kwargs.update(
+            {
+                "ssl_assert_hostname": True,
+                "ssl_show_warn": True,
+                "ca_certs": settings.OPENSEARCH_CA_CERTS,
+            },
+        )
+
+    return OpenSearch(**client_kwargs)


### PR DESCRIPTION
Explanation of issue:

OpenSearch was exhibiting an SSL/TLS handshake error between client app and OpenSearch container on startup. Added a health check condition to the docker compose to make sure OpenSearch is fully initialized before starting the client and found that the OpenSearch certs weren't mounted in the Django app, which was preventing the containers from communicating properly.