### PR TITLE
OpenSearch Healthcheck Fix

### DIFF
--- a/gateway/compose.production.yaml
+++ b/gateway/compose.production.yaml
@@ -33,7 +33,7 @@ services:
         tty: true
         depends_on:
             opensearch:
-                condition: service_started
+                condition: service_healthy
             postgres:
                 condition: service_started
             redis:
@@ -130,12 +130,12 @@ services:
             - "19600:9600"
         networks:
             - sds-gateway-prod-opensearch-net
-        # TODO: Uncomment this when we fix the health check
-        # healthcheck:
-        #    test: ["CMD-SHELL", "curl -k -u ${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD} https://localhost:9200/_cluster/health?pretty | grep -q '\"status\" : \"green\"\\|\"status\" : \"yellow\"'"]
-        #    interval: 30s
-        #    timeout: 10s
-        #    retries: 3
+
+        healthcheck:
+            test: ["CMD-SHELL", "curl -k -u \"$OPENSEARCH_USER:$OPENSEARCH_PASSWORD\" https://localhost:9200/_cluster/health || exit 1"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
 
     postgres:
         # main database for the gateway app

--- a/gateway/compose/production/django/start
+++ b/gateway/compose/production/django/start
@@ -6,8 +6,7 @@ set -o nounset
 
 python /app/manage.py collectstatic --noinput
 
-# TODO: Uncomment this when we fix the health check
-# echo "Initializing OpenSearch indices..."
-# python manage.py init_indices
+echo "Initializing OpenSearch indices..."
+python manage.py init_indices
 
 exec /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:18000 --chdir=/app -k uvicorn_worker.UvicornWorker

--- a/gateway/compose/production/opensearch/opensearch.yaml
+++ b/gateway/compose/production/opensearch/opensearch.yaml
@@ -15,5 +15,6 @@ plugins.security.ssl.http.pemtrustedcas_filepath: /usr/share/opensearch/config/c
 plugins.security.allow_unsafe_democertificates: false
 plugins.security.authcz.admin_dn:
   - 'CN=admin,OU=CRC,O=UNIVERSITY OF NOTRE DAME,L=SOUTH BEND,ST=INDIANA,C=US'
+  - 'CN=sds-gateway-prod-opensearch,OU=CRC,O=UNIVERSITY OF NOTRE DAME,L=SOUTH BEND,ST=INDIANA,C=US'
 plugins.security.nodes_dn:
-  - 'CN=sds.crc.nd.edu,OU=CRC,O=UNIVERSITY OF NOTRE DAME,L=SOUTH BEND,ST=INDIANA,C=US'
+  - 'CN=sds-gateway-prod-opensearch,OU=CRC,O=UNIVERSITY OF NOTRE DAME,L=SOUTH BEND,ST=INDIANA,C=US'


### PR DESCRIPTION
This works locally. If you're having issues on the server, try running:

`docker exec sds-gateway-prod-opensearch /usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/opensearch/config/opensearch-security/ -icl -nhnv -cacert /usr/share/opensearch/config/certs/root-ca.pem -cert /usr/share/opensearch/config/certs/opensearch.pem -key /usr/share/opensearch/config/certs/opensearch-key.pem`

I'm not sure under what circumstances the security admin script needs to be run in this way, but I ran into this warning, which means it needs to run manually: `Will not attempt to create index .opendistro_security and default configs if they are absent. Use securityadmin to initialize cluster`