### PR TITLE
Add Capture Update and Delete methods

### DIFF
--- a/gateway/sds_gateway/api_methods/models.py
+++ b/gateway/sds_gateway/api_methods/models.py
@@ -56,6 +56,12 @@ class BaseModel(models.Model):
 
         abstract = True
 
+    def soft_delete(self) -> None:
+        """Soft delete this record by marking it as deleted."""
+        self.is_deleted = True
+        self.deleted_at = datetime.datetime.now(datetime.UTC)
+        self.save()
+
 
 class File(BaseModel):
     """

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -286,22 +286,21 @@ class CaptureTestCases(APITestCase):
     def test_update_capture_200_new_metadata(self):
         """Test updating a capture returns 200 with new metadata."""
         # update the metadata dict and insert into the capture update payload
-        new_center_freq = 1500000000
-        new_gain = 10.5
-
-        self.drf_metadata["center_freq"] = new_center_freq
-        self.drf_metadata["gain"] = new_gain
+        new_metadata = self.drf_metadata.copy()
+        new_metadata["center_freq"] = 1500000000
+        new_metadata["gain"] = 10.5
 
         with patch(
             "sds_gateway.api_methods.views.capture_endpoints.validate_metadata_by_channel",
-            return_value=self.drf_metadata,
+            return_value=new_metadata,
         ):
             response = self.client.put(
                 self.detail_url(self.drf_capture.uuid),
             )
             assert response.status_code == status.HTTP_200_OK
-            assert response.json()["capture_props"]["center_freq"] == new_center_freq
-            assert response.json()["capture_props"]["gain"] == new_gain
+            response_data = response.json()["capture_props"]
+            assert response_data["center_freq"] == new_metadata["center_freq"]
+            assert response_data["gain"] == new_metadata["gain"]
 
     def test_list_captures_200(self) -> None:
         """Test listing captures returns metadata for all captures."""

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -400,6 +400,7 @@ class CaptureViewSet(viewsets.ViewSet):
             owner=request.user,
             is_deleted=False,
         )
-        target_capture.is_deleted = True
-        target_capture.save()
+        target_capture.soft_delete()
+
+        # return status for soft deletion
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -207,13 +207,12 @@ class CaptureViewSet(viewsets.ViewSet):
                 channel=channel,
             )
         except ValueError as e:
-            msg = f"Error creating capture: {e}"
+            msg = f"Error handling metadata for capture '{capture.uuid}': {e}"
             return Response({"detail": msg}, status=status.HTTP_400_BAD_REQUEST)
-        except os_exceptions.ConnectionError:
-            return Response(
-                {"detail": "OpenSearch service unavailable"},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            )
+        except os_exceptions.ConnectionError as e:
+            msg = f"Error connecting to OpenSearch: {e}"
+            log.error(msg)
+            return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
         get_serializer = CaptureGetSerializer(capture)
         return Response(get_serializer.data, status=status.HTTP_201_CREATED)
@@ -360,13 +359,12 @@ class CaptureViewSet(viewsets.ViewSet):
                 channel=target_capture.channel,
             )
         except ValueError as e:
-            msg = f"Error updating capture: {e}"
+            msg = f"Error handling metadata for capture '{target_capture.uuid}': {e}"
             return Response({"detail": msg}, status=status.HTTP_400_BAD_REQUEST)
-        except os_exceptions.ConnectionError:
-            return Response(
-                {"detail": "OpenSearch service unavailable"},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            )
+        except os_exceptions.ConnectionError as e:
+            msg = f"Error connecting to OpenSearch: {e}"
+            log.error(msg)
+            return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
         # Return updated capture
         serializer = CaptureGetSerializer(target_capture)

--- a/gateway/sds_gateway/api_methods/views/file_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/file_endpoints.py
@@ -1,6 +1,5 @@
 """File operations endpoints for the SDS Gateway API."""
 
-import datetime
 import logging
 from pathlib import Path
 from typing import cast
@@ -408,9 +407,7 @@ class FileViewSet(ViewSet):
             owner=request.user,
             is_deleted=False,
         )
-        target_file.is_deleted = True
-        target_file.deleted_at = datetime.datetime.now(datetime.UTC)
-        target_file.save()
+        target_file.soft_delete()
 
         # return status for soft deletion
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
- Added an update method to capture that only takes pk (then automatically attaches any new files in `top_level_dir` and re-indexes the metadata file for the capture).
- Added a delete method that soft deletes capture (`is_deleted=True`).
- Added a serialized list of files (uuid, name, and directory) to capture retrieval.
- Changed response for no files returned in capture list from 404 to empty list.
- Added tests for update/delete captures.