### PR TITLE
Login redirect, API doc access fixes

### DIFF
--- a/gateway/config/settings/base.py
+++ b/gateway/config/settings/base.py
@@ -403,10 +403,9 @@ SPECTACULAR_SETTINGS: dict[str, Any] = {
     "POSTPROCESSING_HOOKS": [
         "sds_gateway.api_methods.utils.spectacular_hooks.remove_irrelevant_auth_schemes",
     ],
-    "SERVE_PERMISSIONS": [
-        "rest_framework.permissions.IsAuthenticated",
-    ],  # Allow only authenticated users to access the schema
     "SCHEMA_PATH_PREFIX": f"/api/{API_VERSION}",
+    "SERVE_PUBLIC": True,
+    "SERVE_AUTHENTICATION": None,
 }
 # django-webpack-loader
 # ------------------------------------------------------------------------------

--- a/gateway/config/urls.py
+++ b/gateway/config/urls.py
@@ -10,6 +10,7 @@ from drf_spectacular.views import SpectacularAPIView
 from drf_spectacular.views import SpectacularSwaggerView
 from loguru import logger as log
 from rest_framework.authtoken.views import obtain_auth_token
+from rest_framework.permissions import AllowAny
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="pages/home.html"), name="home"),
@@ -42,7 +43,10 @@ urlpatterns += [
     path(f"api/{settings.API_VERSION}/auth-token/", obtain_auth_token),
     path(
         f"api/{settings.API_VERSION}/schema/",
-        SpectacularAPIView.as_view(),
+        SpectacularAPIView.as_view(
+            permission_classes=[AllowAny],
+            authentication_classes=[],
+        ),
         name="api-schema",
     ),
     path(
@@ -50,6 +54,8 @@ urlpatterns += [
         SpectacularSwaggerView.as_view(
             template_name="swagger-ui.html",
             url_name="api-schema",
+            permission_classes=[AllowAny],
+            authentication_classes=[],
         ),
         name="api-docs",
     ),

--- a/gateway/sds_gateway/templates/pages/home.html
+++ b/gateway/sds_gateway/templates/pages/home.html
@@ -29,7 +29,7 @@
                         <div class="hero-box">
                             <h2>API Gateway Documentation</h2>
                             <p>
-                                <a href="https://sds.crc.nd.edu/api/v1/docs/">Documentation of API endpoints</a> of SpectrumX Data System Gateway
+                                <a href="{% url 'api-docs' %}">Documentation of API endpoints</a> of SpectrumX Data System Gateway
                             </p>
                         </div>
                         <div class="hero-box">

--- a/gateway/sds_gateway/users/api/views.py
+++ b/gateway/sds_gateway/users/api/views.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
 from loguru import logger as log
 from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
@@ -24,6 +25,7 @@ from sds_gateway.users.models import UserAPIKey
 from .serializers import UserSerializer
 
 
+@extend_schema(exclude=True)
 class UserViewSet(
     RetrieveModelMixin,
     ListModelMixin,
@@ -46,6 +48,7 @@ class UserViewSet(
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 
 
+@extend_schema(exclude=True)
 class GetAPIKeyView(APIView):
     permission_classes = [IsAuthenticated]
     authentication_classes = [TokenAuthentication]

--- a/gateway/sds_gateway/users/mixins.py
+++ b/gateway/sds_gateway/users/mixins.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import AccessMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -20,3 +21,10 @@ class ApprovedUserRequiredMixin(AccessMixin):
             )
             return redirect(reverse("home"))
         return super().dispatch(request, *args, **kwargs)
+
+
+class Auth0LoginRequiredMixin(LoginRequiredMixin):
+    """Custom mixin that redirects to Auth0 login instead of the default login page"""
+
+    def get_login_url(self):
+        return reverse("auth0_login")

--- a/gateway/sds_gateway/users/views.py
+++ b/gateway/sds_gateway/users/views.py
@@ -2,7 +2,6 @@ import datetime
 from typing import Any
 from typing import cast
 
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.paginator import Paginator
 from django.db.models.query import QuerySet as Queryset
@@ -20,11 +19,12 @@ from sds_gateway.api_methods.models import File
 from sds_gateway.api_methods.models import KeySources
 from sds_gateway.api_methods.serializers.file_serializers import FileGetSerializer
 from sds_gateway.users.mixins import ApprovedUserRequiredMixin
+from sds_gateway.users.mixins import Auth0LoginRequiredMixin
 from sds_gateway.users.models import User
 from sds_gateway.users.models import UserAPIKey
 
 
-class UserDetailView(LoginRequiredMixin, DetailView):
+class UserDetailView(Auth0LoginRequiredMixin, DetailView):
     model = User
     slug_field = "id"
     slug_url_kwarg = "id"
@@ -33,7 +33,7 @@ class UserDetailView(LoginRequiredMixin, DetailView):
 user_detail_view = UserDetailView.as_view()
 
 
-class UserUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
+class UserUpdateView(Auth0LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     model = User
     fields = ["name"]
     success_message = _("Information successfully updated")
@@ -50,7 +50,7 @@ class UserUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
 user_update_view = UserUpdateView.as_view()
 
 
-class UserRedirectView(LoginRequiredMixin, RedirectView):
+class UserRedirectView(Auth0LoginRequiredMixin, RedirectView):
     permanent = False
 
     def get_redirect_url(self):
@@ -60,7 +60,7 @@ class UserRedirectView(LoginRequiredMixin, RedirectView):
 user_redirect_view = UserRedirectView.as_view()
 
 
-class GenerateAPIKeyView(ApprovedUserRequiredMixin, View):
+class GenerateAPIKeyView(ApprovedUserRequiredMixin, Auth0LoginRequiredMixin, View):
     template_name = "users/user_api_key.html"
 
     def get(self, request, *args, **kwargs):
@@ -125,7 +125,7 @@ class GenerateAPIKeyView(ApprovedUserRequiredMixin, View):
 user_generate_api_key_view = GenerateAPIKeyView.as_view()
 
 
-class ListFilesView(LoginRequiredMixin, View):
+class ListFilesView(Auth0LoginRequiredMixin, View):
     template_name = "users/file_list.html"
 
     def get(self, request, *args, **kwargs) -> HttpResponse:
@@ -150,7 +150,7 @@ class ListFilesView(LoginRequiredMixin, View):
 user_file_list_view = ListFilesView.as_view()
 
 
-class FileDetailView(LoginRequiredMixin, DetailView):
+class FileDetailView(Auth0LoginRequiredMixin, DetailView):
     model = File
     slug_field = "uuid"
     slug_url_kwarg = "uuid"


### PR DESCRIPTION
- Added a mixin to redirect to the `auth0_login` URL
- Changed the view permissions on the API docs and schema
- Fixed the link to the API docs on the home page
- Hide the internal users API endpoints from the docs