### PR TITLE
Fix file upload metadata

### DIFF
--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -311,6 +311,8 @@ class GatewayClient:
         payload = {
             "directory": str(file_instance.directory),
             "media_type": file_instance.media_type,
+            "name": file_instance.name,
+            "permissions": file_instance.permissions,
         }
         all_chunks: bytes = b""
         with (

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -23,6 +23,7 @@ from spectrumx.models.captures import CaptureType
 from .errors import AuthError
 from .errors import FileError
 from .models.files import File
+from .models.files import FileUpload
 from .ops import network
 from .utils import is_test_env
 from .utils import log_user_warning
@@ -308,12 +309,7 @@ class GatewayClient:
             msg = "Attempting to upload a remote file. Download it first."
             raise FileError(msg)
 
-        payload = {
-            "directory": str(file_instance.directory),
-            "media_type": file_instance.media_type,
-            "name": file_instance.name,
-            "permissions": file_instance.permissions,
-        }
+        payload = FileUpload.from_file(file_instance).model_dump()
         all_chunks: bytes = b""
         with (
             file_instance.local_path.open("rb") as file_ptr,

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -24,6 +24,7 @@ from .errors import AuthError
 from .errors import FileError
 from .models.files import File
 from .models.files import FileUpload
+from .models.files import PermissionRepresentation
 from .ops import network
 from .utils import is_test_env
 from .utils import log_user_warning
@@ -309,7 +310,9 @@ class GatewayClient:
             msg = "Attempting to upload a remote file. Download it first."
             raise FileError(msg)
 
-        payload = FileUpload.from_file(file_instance).model_dump()
+        payload = FileUpload.from_file(file_instance).model_dump(
+            context={"mode": PermissionRepresentation.STRING}
+        )
         all_chunks: bytes = b""
         with (
             file_instance.local_path.open("rb") as file_ptr,

--- a/sdk/src/spectrumx/models/files.py
+++ b/sdk/src/spectrumx/models/files.py
@@ -115,4 +115,20 @@ class File(SDSModel):
         return this_sum == other_sum
 
 
-__all__ = ["File"]
+class FileUpload(SDSModel):
+    name: str | None
+    directory: str
+    media_type: str
+    permissions: str | None
+
+    @staticmethod
+    def from_file(file: File) -> "FileUpload":
+        return FileUpload(
+            name=file.name,
+            directory=str(file.directory),
+            media_type=file.media_type,
+            permissions=file.permissions,
+        )
+
+
+__all__ = ["File", "FileUpload"]

--- a/sdk/src/spectrumx/models/files/__init__.py
+++ b/sdk/src/spectrumx/models/files/__init__.py
@@ -1,0 +1,8 @@
+"""Data models for the SpectrumX Data System SDK."""
+
+from spectrumx.models.files.file import File
+from spectrumx.models.files.file import FileUpload
+from spectrumx.models.files.permission import PermissionRepresentation
+from spectrumx.models.files.permission import UnixPermissionStr
+
+__all__ = ["File", "FileUpload", "PermissionRepresentation", "UnixPermissionStr"]

--- a/sdk/src/spectrumx/models/files/permission.py
+++ b/sdk/src/spectrumx/models/files/permission.py
@@ -1,0 +1,125 @@
+import sys
+
+if sys.version_info < (3, 11):  # noqa: UP036
+    from backports.strenum import StrEnum  # noqa: UP035 # Required backport
+else:
+    from enum import StrEnum
+
+from typing import Annotated
+from typing import Any
+
+from pydantic import BeforeValidator
+from pydantic import Field
+from pydantic import PlainSerializer
+from pydantic import SerializationInfo
+from pydantic import StringConstraints
+from pydantic import TypeAdapter
+
+PermissionOct = Annotated[
+    int,
+    Field(
+        ge=0,
+        le=511,
+        description="Octal representation of Unix file permissions (e.g., 0x755).",
+        examples=["0o755", "0o644", "0o777"],
+    ),
+]
+
+PermissionStr = Annotated[
+    str,
+    Field(
+        description="Unix file permission string (e.g. 'rwxr-xr--')",
+        examples=["rwxr-xr-x", "rw-r--r--", "rwx------"],
+    ),
+    StringConstraints(
+        strip_whitespace=True, min_length=9, max_length=9, pattern=r"^[rwx-]{9}$"
+    ),
+]
+PermissionStrAdapter = TypeAdapter(PermissionStr)
+
+
+# Helper functions
+def octal_to_unix_perm_string(value: int) -> str:
+    """
+    Convert an octal Unix file permission to a string representation.
+
+    :param value: An int representing the file permission in octal format (e.g., 0o755)
+    :return: A 9-character string representing Unix permissions (e.g., 'rwxr-xr-x')
+    :raises ValueError: If the input is not a valid octal Unix permission.
+    """
+    perm_oct = TypeAdapter(PermissionOct).validate_python(value)
+
+    mapping = {
+        0: "---",
+        1: "--x",
+        2: "-w-",
+        3: "-wx",
+        4: "r--",
+        5: "r-x",
+        6: "rw-",
+        7: "rwx",
+    }
+
+    return "".join(mapping[(perm_oct >> (3 * i)) & 0o7] for i in reversed(range(3)))
+
+
+def unix_perm_string_to_octal(value: str) -> int | ValueError:
+    """
+    Convert a Unix permission string (e.g., 'rwxr-xr-x') to an octal integer.
+
+    :param value: A 9-character Unix permission string (e.g., 'rw-r--r--')
+    :return: An integer representing the octal value of the permission (e.g., 0o755)
+    :raises ValueError: If the input string is not a valid Unix permission string.
+    """
+    perm_str = PermissionStrAdapter.validate_python(value)
+
+    one_hot = "".join(["0" if flag == "-" else "1" for flag in perm_str])
+    return int(one_hot, base=2)
+
+
+def unix_perm_from_any(value: Any) -> str | ValueError:
+    if isinstance(value, int):
+        return octal_to_unix_perm_string(value)
+    if isinstance(value, str):
+        return PermissionStrAdapter.validate_python(value)
+
+    msg = f"Invalid Unix permission format: {value}"
+    return ValueError(msg)
+
+
+class PermissionRepresentation(StrEnum):
+    STRING = "string"
+    OCTAL = "octal"
+
+    @classmethod
+    def _missing_(cls, value):
+        """Raises an exception when an unknown value is provided."""
+        msg = f"Invalid PermissionRepresentation value: {value}"
+        raise ValueError(msg)
+
+    def convert(self, value: str) -> str:
+        if self == PermissionRepresentation.OCTAL:
+            return f"0o{unix_perm_string_to_octal(value):03o}"
+        return value
+
+
+# Serialization
+def serialize_unix_permission(value: Any, info: SerializationInfo):
+    """Serialize Unix permission based on context (`octal` or `string`)."""
+
+    # If we have no context return the string representation
+    if info.context is None:
+        return value
+
+    # Get the mode from the context and default to string
+    mode = info.context.get("mode", PermissionRepresentation.STRING)
+    return PermissionRepresentation(mode).convert(value)
+
+
+UnixPermissionStr = Annotated[
+    PermissionOct | PermissionStr,
+    BeforeValidator(unix_perm_from_any),
+    PlainSerializer(serialize_unix_permission, return_type=str),
+]
+
+__all__ = ["PermissionRepresentation", "UnixPermissionStr"]

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -660,7 +660,7 @@ wheels = [
 
 [[package]]
 name = "spectrumx"
-version = "0.1.7a0"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
When uploading a file, the name and permissions of the file object are not included in the upload. This PR includes a fix for that as well as replacing the dictionary of parameters with a Pydantic model and also introduces a Pydantic model for representing file permissions. 