### PR TITLE
Ensure windows compatibility

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -288,7 +288,7 @@
         log_cli              = true
         log_cli_level        = "WARN"
         log_date_format      = "%Y-%m-%d %H:%M:%S"
-        markers              = ["integration: marks a test as an integration test"]
+        markers              = ["integration: marks a test as an integration test", "linux: marks a test to run on linux", "darwin: marks a test to run on Mac OS", "win32: marks a test to run on windows"]
         minversion           = "8.0"
         testpaths            = ["tests"]
         verbosity_test_cases = 2

--- a/sdk/src/spectrumx/api/captures.py
+++ b/sdk/src/spectrumx/api/captures.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -14,7 +15,7 @@ from spectrumx.models.captures import CaptureOrigin
 from spectrumx.models.captures import CaptureType
 
 if TYPE_CHECKING:
-    from pathlib import PurePosixPath
+    from pathlib import Path
 
     from spectrumx.gateway import GatewayClient
 
@@ -35,7 +36,7 @@ class CaptureAPI:
     def create(
         self,
         *,
-        top_level_dir: PurePosixPath,
+        top_level_dir: Path | PurePosixPath,
         capture_type: CaptureType,
         index_name: str = "",
         channel: str | None = None,
@@ -50,6 +51,8 @@ class CaptureAPI:
         index_name = index_mapping.get(capture_type, index_name)
         if not index_name:
             log.warning(f"Could not find an index for {capture_type=}")
+
+        top_level_dir = PurePosixPath(top_level_dir)
         log.debug(
             f"Creating capture with {top_level_dir=}, "
             f"{channel=}, {capture_type=}, {index_name=}, {scan_group=}"

--- a/sdk/src/spectrumx/api/captures.py
+++ b/sdk/src/spectrumx/api/captures.py
@@ -14,7 +14,7 @@ from spectrumx.models.captures import CaptureOrigin
 from spectrumx.models.captures import CaptureType
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from pathlib import PurePosixPath
 
     from spectrumx.gateway import GatewayClient
 
@@ -35,7 +35,7 @@ class CaptureAPI:
     def create(
         self,
         *,
-        top_level_dir: Path,
+        top_level_dir: PurePosixPath,
         capture_type: CaptureType,
         index_name: str = "",
         channel: str | None = None,

--- a/sdk/src/spectrumx/api/sds_files.py
+++ b/sdk/src/spectrumx/api/sds_files.py
@@ -10,6 +10,7 @@ from enum import Enum
 from enum import auto
 from multiprocessing.synchronize import RLock
 from pathlib import Path
+from pathlib import PurePosixPath
 
 from loguru import logger as log
 from pydantic import UUID4
@@ -138,7 +139,7 @@ def download_file(
 def list_files(
     *,
     client: Client,
-    sds_path: Path | str,
+    sds_path: PurePosixPath | str,
     verbose: bool = False,
 ) -> Paginator[File]:
     """Lists files in a given SDS path.
@@ -165,7 +166,7 @@ def upload_file(
     *,
     client: Client,
     local_file: File | Path | str,
-    sds_path: Path | str = "/",
+    sds_path: PurePosixPath | str = "/",
 ) -> File:
     """Uploads a file to SDS.
 
@@ -188,7 +189,7 @@ def upload_file(
         msg = f"file_path must be a Path, str, or File instance, not {type(local_file)}"
         raise TypeError(msg)
     local_file = Path(local_file) if isinstance(local_file, str) else local_file
-    sds_path = Path(sds_path)
+    sds_path = PurePosixPath(sds_path)
 
     # construct the file instance if needed
     if isinstance(local_file, File):

--- a/sdk/src/spectrumx/api/sds_files.py
+++ b/sdk/src/spectrumx/api/sds_files.py
@@ -139,7 +139,7 @@ def download_file(
 def list_files(
     *,
     client: Client,
-    sds_path: PurePosixPath | str,
+    sds_path: PurePosixPath | Path | str,
     verbose: bool = False,
 ) -> Paginator[File]:
     """Lists files in a given SDS path.
@@ -166,7 +166,7 @@ def upload_file(
     *,
     client: Client,
     local_file: File | Path | str,
-    sds_path: PurePosixPath | str = "/",
+    sds_path: PurePosixPath | Path | str = "/",
 ) -> File:
     """Uploads a file to SDS.
 

--- a/sdk/src/spectrumx/client.py
+++ b/sdk/src/spectrumx/client.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Mapping
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -165,7 +166,7 @@ class Client:
     def download(
         self,
         *,
-        from_sds_path: Path | str,
+        from_sds_path: PurePosixPath | str,
         to_local_path: Path | str,
         skip_contents: bool = False,
         overwrite: bool = False,
@@ -182,7 +183,7 @@ class Client:
         Returns:
             A list of results for each file discovered and downloaded.
         """
-        from_sds_path = Path(from_sds_path)
+        from_sds_path = PurePosixPath(from_sds_path)
         to_local_path = Path(to_local_path)
 
         # local vars
@@ -283,7 +284,7 @@ class Client:
         return results
 
     def list_files(
-        self, sds_path: Path | str, *, verbose: bool = False
+        self, sds_path: PurePosixPath | str, *, verbose: bool = False
     ) -> Paginator[File]:
         """Lists files in a given SDS path.
 
@@ -337,7 +338,7 @@ class Client:
         self,
         *,
         local_path: Path | str,
-        sds_path: Path | str = "/",
+        sds_path: PurePosixPath | str = "/",
         verbose: bool = True,
     ) -> list[Result[File]]:
         """Uploads a file or directory to SDS.
@@ -371,7 +372,7 @@ class Client:
         self,
         *,
         local_file: File | Path | str,
-        sds_path: Path | str = "/",
+        sds_path: PurePosixPath | str = "/",
     ) -> File:
         """Uploads a file to SDS.
 

--- a/sdk/src/spectrumx/client.py
+++ b/sdk/src/spectrumx/client.py
@@ -166,7 +166,7 @@ class Client:
     def download(
         self,
         *,
-        from_sds_path: PurePosixPath | str,
+        from_sds_path: PurePosixPath | Path | str,
         to_local_path: Path | str,
         skip_contents: bool = False,
         overwrite: bool = False,
@@ -284,7 +284,7 @@ class Client:
         return results
 
     def list_files(
-        self, sds_path: PurePosixPath | str, *, verbose: bool = False
+        self, sds_path: PurePosixPath | Path | str, *, verbose: bool = False
     ) -> Paginator[File]:
         """Lists files in a given SDS path.
 
@@ -338,7 +338,7 @@ class Client:
         self,
         *,
         local_path: Path | str,
-        sds_path: PurePosixPath | str = "/",
+        sds_path: PurePosixPath | Path | str = "/",
         verbose: bool = True,
     ) -> list[Result[File]]:
         """Uploads a file or directory to SDS.
@@ -372,7 +372,7 @@ class Client:
         self,
         *,
         local_file: File | Path | str,
-        sds_path: PurePosixPath | str = "/",
+        sds_path: PurePosixPath | Path | str = "/",
     ) -> File:
         """Uploads a file to SDS.
 

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -9,7 +9,6 @@ if sys.version_info < (3, 11):  # noqa: UP036
 else:
     from enum import StrEnum
 from http import HTTPStatus
-from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Annotated
 from typing import Any
@@ -120,9 +119,9 @@ class GatewayClient:
             raise ValueError(msg)
 
         assert API_TARGET_VERSION.startswith("v"), "API version must start with 'v'."
-        url_path = Path(f"{API_PATH}/{API_TARGET_VERSION}/{endpoint_fmt}")
+        url_path = f"{API_PATH}{API_TARGET_VERSION}{endpoint_fmt}"
         if asset_id is not None:
-            url_path /= asset_id
+            url_path = f"{url_path}/{asset_id}"
         url = f"{self.base_url}{url_path}/"
 
         is_verify = not is_test_env()

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -10,6 +10,7 @@ else:
     from enum import StrEnum
 from http import HTTPStatus
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Annotated
 from typing import Any
 
@@ -246,7 +247,7 @@ class GatewayClient:
     def list_files(
         self,
         *,
-        sds_path: Path,
+        sds_path: PurePosixPath,
         page: int = 1,
         page_size: int = 30,
         verbose: bool = False,
@@ -430,7 +431,7 @@ class GatewayClient:
     def create_capture(
         self,
         *,
-        top_level_dir: Path,
+        top_level_dir: PurePosixPath,
         capture_type: str,
         index_name: str,
         channel: str | None = None,

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -9,6 +9,7 @@ if sys.version_info < (3, 11):  # noqa: UP036
 else:
     from enum import StrEnum
 from http import HTTPStatus
+from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Annotated
 from typing import Any
@@ -246,7 +247,7 @@ class GatewayClient:
     def list_files(
         self,
         *,
-        sds_path: PurePosixPath,
+        sds_path: PurePosixPath | Path | str,
         page: int = 1,
         page_size: int = 30,
         verbose: bool = False,
@@ -430,7 +431,7 @@ class GatewayClient:
     def create_capture(
         self,
         *,
-        top_level_dir: PurePosixPath,
+        top_level_dir: PurePosixPath | Path | str,
         capture_type: str,
         index_name: str,
         channel: str | None = None,

--- a/sdk/src/spectrumx/models/captures.py
+++ b/sdk/src/spectrumx/models/captures.py
@@ -8,6 +8,7 @@ else:
     from enum import StrEnum
 
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Annotated
 from typing import Any
 
@@ -62,7 +63,7 @@ class Capture(BaseModel):
     capture_type: Annotated[CaptureType, Field(description=_d_capture_type)]
     index_name: Annotated[str, Field(max_length=255, description=_d_index_name)]
     origin: Annotated[CaptureOrigin, Field(description=_d_origin)]
-    top_level_dir: Annotated[Path, Field(description=_d_top_level_dir)]
+    top_level_dir: Annotated[PurePosixPath, Field(description=_d_top_level_dir)]
     uuid: Annotated[UUID4, Field(description=_d_uuid)]
     files: Annotated[list[CaptureFile], Field(description=_d_capture_files)]
 

--- a/sdk/src/spectrumx/models/files/file.py
+++ b/sdk/src/spectrumx/models/files/file.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from multiprocessing import RLock
 from multiprocessing.synchronize import RLock as RLockT
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Annotated
 
 from pydantic import ConfigDict
@@ -37,7 +38,7 @@ class File(SDSModel):
     """
 
     created_at: datetime
-    directory: Annotated[Path, Field(default_factory=Path)]
+    directory: Annotated[PurePosixPath, Field(default_factory=PurePosixPath)]
     expiration_date: datetime | None
     media_type: str
     name: str
@@ -59,7 +60,7 @@ class File(SDSModel):
         """Post-initialization steps."""
 
     @property
-    def path(self) -> Path:
+    def path(self) -> PurePosixPath:
         """Returns the path to the file, relative to the owner's root on SDS."""
         return self.directory / self.name
 

--- a/sdk/src/spectrumx/ops/files.py
+++ b/sdk/src/spectrumx/ops/files.py
@@ -78,7 +78,7 @@ def get_file_updated_at(file_path: Path) -> datetime:
     return datetime.fromtimestamp(file_path.stat().st_mtime, tz=_tz)
 
 
-def construct_file(file_path: Path, sds_path: PurePosixPath) -> File:
+def construct_file(file_path: Path, sds_path: Path | PurePosixPath) -> File:
     """Constructs a file instance from a local file. File has to exist on disk."""
     file_path = Path(file_path)
     if not file_path.exists():
@@ -89,7 +89,7 @@ def construct_file(file_path: Path, sds_path: PurePosixPath) -> File:
         expiration_date=None,
         local_path=file_path,
         size=file_path.stat().st_size,
-        directory=sds_path,
+        directory=PurePosixPath(sds_path),
         media_type=get_file_media_type(file_path),
         created_at=get_file_created_at(file_path),
         updated_at=get_file_updated_at(file_path),

--- a/sdk/src/spectrumx/ops/files.py
+++ b/sdk/src/spectrumx/ops/files.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
+from pathlib import PurePosixPath
 
 from loguru import logger as log
 
@@ -77,7 +78,7 @@ def get_file_updated_at(file_path: Path) -> datetime:
     return datetime.fromtimestamp(file_path.stat().st_mtime, tz=_tz)
 
 
-def construct_file(file_path: Path, sds_path: Path) -> File:
+def construct_file(file_path: Path, sds_path: PurePosixPath) -> File:
     """Constructs a file instance from a local file. File has to exist on disk."""
     file_path = Path(file_path)
     if not file_path.exists():
@@ -163,7 +164,9 @@ def get_valid_files(local_path: Path, *, warn_skipped: bool = False) -> Generato
         try:
             successful_files += 1
             local_rel_path = file_path.relative_to(local_path).parent
-            yield construct_file(file_path=file_path, sds_path=local_rel_path)
+            yield construct_file(
+                file_path=file_path, sds_path=PurePosixPath(local_rel_path)
+            )
         except FileNotFoundError:
             continue
     log_user(
@@ -190,7 +193,7 @@ def generate_sample_file(uuid_to_set: uuid.UUID) -> File:
         name=f"dry-run-{trailing_uuid_hex}.txt",
         media_type="text/plain",
         size=888,
-        directory=Path("./sds-files/dry-run/"),
+        directory=PurePosixPath("./sds-files/dry-run/"),
         permissions="rw-rw-r--",
         created_at=created_at,
         updated_at=updated_at,

--- a/sdk/src/spectrumx/ops/pagination.py
+++ b/sdk/src/spectrumx/ops/pagination.py
@@ -4,6 +4,7 @@ import json
 import sys
 import time
 import uuid
+from pathlib import Path
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 from typing import Any
@@ -66,7 +67,7 @@ class Paginator(Generic[T]):
         *,
         Entry: type[SDSModel],  # noqa: N803
         gateway: GatewayClient,
-        sds_path: PurePosixPath | str,
+        sds_path: PurePosixPath | Path | str,
         dry_run: bool = False,
         page_size: int = 30,
         start_page: int = 1,

--- a/sdk/src/spectrumx/ops/pagination.py
+++ b/sdk/src/spectrumx/ops/pagination.py
@@ -4,7 +4,7 @@ import json
 import sys
 import time
 import uuid
-from pathlib import Path
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Generic
@@ -66,7 +66,7 @@ class Paginator(Generic[T]):
         *,
         Entry: type[SDSModel],  # noqa: N803
         gateway: GatewayClient,
-        sds_path: Path | str,
+        sds_path: PurePosixPath | str,
         dry_run: bool = False,
         page_size: int = 30,
         start_page: int = 1,
@@ -97,8 +97,8 @@ class Paginator(Generic[T]):
         ):  # pragma: no cover
             msg = "Total matches must be an integer."
             raise ValueError(msg)
-        if not isinstance(sds_path, (Path, str)):  # pragma: no cover
-            msg = "SDS path must be a Path or str."
+        if not isinstance(sds_path, (PurePosixPath, str)):  # pragma: no cover
+            msg = "SDS path must be a PurePosixPath or str."
             raise TypeError(msg)
         if not isinstance(gateway, GatewayClient):  # pragma: no cover
             msg = "Gateway client must be provided."
@@ -111,7 +111,7 @@ class Paginator(Generic[T]):
         self._gateway = gateway
         self._next_page = start_page
         self._page_size = page_size
-        self._sds_path = Path(sds_path)
+        self._sds_path = PurePosixPath(sds_path)
         self._total_matches = total_matches if total_matches else 1
         self._verbose: bool = verbose
 

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 import random
+import sys
 import uuid
 from collections.abc import Generator
 from pathlib import Path
@@ -25,6 +26,18 @@ except ImportError:
     log.warning("Install rich for better tracebacks")
 
 enable_logging()
+
+# Platform Specific Testing
+PLATFORMS = set("darwin linux win32".split())
+
+
+def pytest_runtest_setup(item):
+    supported_platforms = PLATFORMS.intersection(
+        mark.name for mark in item.iter_markers()
+    )
+    plat = sys.platform
+    if supported_platforms and plat not in supported_platforms:
+        pytest.skip(f"cannot run on platform {plat}")
 
 
 # ==== fixtures

--- a/sdk/tests/integration/test_captures.py
+++ b/sdk/tests/integration/test_captures.py
@@ -3,6 +3,7 @@
 import json
 from collections.abc import Generator
 from pathlib import Path
+from pathlib import PurePosixPath
 
 import pytest
 from loguru import logger as log
@@ -74,7 +75,9 @@ def test_capture_creation_drf(integration_client: Client) -> None:
     # suffix path_after_capture_data with a random name to avoid conflicts between runs
     path_after_capture_data = dir_top_level.relative_to(dir_integration_data)
     random_suffix = get_random_line(10, include_punctuation=False)
-    path_after_capture_data = path_after_capture_data / f"test-{random_suffix}"
+    path_after_capture_data = (
+        PurePosixPath(path_after_capture_data) / f"test-{random_suffix}"
+    )
 
     _upload_assets(
         integration_client=integration_client,
@@ -85,8 +88,9 @@ def test_capture_creation_drf(integration_client: Client) -> None:
     # ACT
 
     # create a capture
+    capture_top_level = PurePosixPath("/") / path_after_capture_data
     capture = integration_client.captures.create(
-        top_level_dir=Path(f"/{path_after_capture_data}"),
+        top_level_dir=capture_top_level,
         channel=drf_channel,
         capture_type=CaptureType.DigitalRF,
     )
@@ -97,7 +101,7 @@ def test_capture_creation_drf(integration_client: Client) -> None:
     assert capture.uuid is not None, "Capture UUID should not be None"
     assert capture.capture_type == CaptureType.DigitalRF
     assert capture.channel == drf_channel
-    assert capture.top_level_dir == Path(f"/{path_after_capture_data}")
+    assert capture.top_level_dir == capture_top_level
 
     # test capture properties
     assert capture.capture_props["start_bound"] == cap_start_bound
@@ -139,7 +143,7 @@ def test_capture_creation_rh(integration_client: Client) -> None:
     # suffix path_after_capture_data with a random name to avoid conflicts between runs
     rel_path_capture = dir_top_level.relative_to(dir_integration_data)
     random_suffix = get_random_line(10, include_punctuation=False)
-    rel_path_capture = rel_path_capture / f"test-{random_suffix}"
+    rel_path_capture = PurePosixPath(rel_path_capture) / f"test-{random_suffix}"
 
     _upload_assets(
         integration_client=integration_client,
@@ -153,8 +157,9 @@ def test_capture_creation_rh(integration_client: Client) -> None:
         radiohound_data = json.load(fp_json)
 
     # create a capture
+    capture_top_level = PurePosixPath("/") / rel_path_capture
     capture = integration_client.captures.create(
-        top_level_dir=rel_path_capture,
+        top_level_dir=capture_top_level,
         scan_group=radiohound_data["scan_group"],
         capture_type=CaptureType.RadioHound,
     )
@@ -164,7 +169,7 @@ def test_capture_creation_rh(integration_client: Client) -> None:
     # basic capture information
     assert capture.uuid is not None, "Capture UUID should not be None"
     assert capture.capture_type == CaptureType.RadioHound
-    assert capture.top_level_dir == rel_path_capture
+    assert capture.top_level_dir == capture_top_level
 
     # test capture metadata
     assert capture.scan_group is not None, "Scan group should not be None"
@@ -287,7 +292,9 @@ def test_capture_update_rh(integration_client: Client) -> None:
     # suffix path_after_capture_data with a random name to avoid conflicts between runs
     rh_capture_update_sds_path = dir_top_level.relative_to(dir_integration_data)
     random_suffix = get_random_line(10, include_punctuation=False)
-    rh_capture_update_sds_path = rh_capture_update_sds_path / f"test-{random_suffix}"
+    rh_capture_update_sds_path = (
+        PurePosixPath(rh_capture_update_sds_path) / f"test-{random_suffix}"
+    )
 
     _upload_assets(
         integration_client=integration_client,
@@ -299,8 +306,9 @@ def test_capture_update_rh(integration_client: Client) -> None:
         radiohound_data = json.load(fp_json)
 
     # create a capture
+    capture_top_level = PurePosixPath("/") / rh_capture_update_sds_path
     capture = integration_client.captures.create(
-        top_level_dir=Path(f"/{rh_capture_update_sds_path}"),
+        top_level_dir=capture_top_level,
         scan_group=radiohound_data["scan_group"],
         capture_type=CaptureType.RadioHound,
     )
@@ -310,7 +318,7 @@ def test_capture_update_rh(integration_client: Client) -> None:
     # basic capture information
     assert capture.uuid is not None, "Capture UUID should not be None"
     assert capture.capture_type == CaptureType.RadioHound
-    assert capture.top_level_dir == Path(f"/{rh_capture_update_sds_path}")
+    assert capture.top_level_dir == capture_top_level
 
     # test capture metadata
     assert capture.capture_props, "Capture properties should not be empty"
@@ -419,7 +427,7 @@ def test_capture_reading_drf(integration_client: Client) -> None:
 
 def _upload_assets(
     integration_client: Client,
-    sds_path: Path,
+    sds_path: PurePosixPath,
     local_path: Path,
 ) -> None:
     """Helper to upload a local directory to SDS and assert success."""

--- a/sdk/tests/integration/test_captures.py
+++ b/sdk/tests/integration/test_captures.py
@@ -427,7 +427,7 @@ def test_capture_reading_drf(integration_client: Client) -> None:
 
 def _upload_assets(
     integration_client: Client,
-    sds_path: PurePosixPath,
+    sds_path: Path | PurePosixPath,
     local_path: Path,
 ) -> None:
     """Helper to upload a local directory to SDS and assert success."""

--- a/sdk/tests/integration/test_file_ops.py
+++ b/sdk/tests/integration/test_file_ops.py
@@ -3,6 +3,7 @@
 import time
 import uuid
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -101,7 +102,7 @@ def test_upload_single_file(
     integration_client: Client, temp_file_with_text_contents: Path
 ) -> None:
     """Test file upload to SDS."""
-    sds_path = Path("/")
+    sds_path = PurePosixPath("/")
     local_file = construct_file(temp_file_with_text_contents, sds_path=sds_path)
     uploaded_file = integration_client.upload_file(
         local_file=temp_file_with_text_contents, sds_path=sds_path
@@ -233,7 +234,7 @@ def test_upload_files_in_bulk(integration_client: Client, temp_file_tree: Path) 
     random_subdir_name = get_random_line(10, include_punctuation=False)
     results = integration_client.upload(
         local_path=temp_file_tree,
-        sds_path=Path("/test-tree") / random_subdir_name,
+        sds_path=PurePosixPath("/test-tree") / random_subdir_name,
         verbose=True,
     )
     log.info(f"Uploaded {len(results)} files.")
@@ -271,7 +272,7 @@ def test_upload_large_file(
     temp_large_binary_file: Path,
 ) -> None:
     """Tests uploading a large file to SDS."""
-    sds_path = Path("/")
+    sds_path = PurePosixPath("/")
     local_file = construct_file(temp_large_binary_file, sds_path=sds_path)
     uploaded_file = integration_client.upload_file(
         local_file=temp_large_binary_file, sds_path=sds_path
@@ -310,7 +311,7 @@ def test_check_file_content_non_existing(
     temp_large_binary_file: Path,
 ) -> None:
     """The file content checker must indicate new files don't exist in SDS."""
-    file_instance = construct_file(temp_large_binary_file, sds_path=Path("./"))
+    file_instance = construct_file(temp_large_binary_file, sds_path=PurePosixPath("./"))
     file_contents_check = integration_client._gateway.check_file_contents_exist(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         file_instance
     )
@@ -347,7 +348,7 @@ def test_check_file_content_identical(
 ) -> None:
     """The file content checker must indicate when files are identical."""
     random_string = get_random_line(10, include_punctuation=False)
-    sds_path = Path("/") / random_string
+    sds_path = PurePosixPath("/") / random_string
     file_instance = construct_file(temp_file_with_text_contents, sds_path=sds_path)
 
     # upload the file to sds
@@ -395,7 +396,7 @@ def test_check_file_content_name_changed(
 ) -> None:
     """The file content checker must indicate when file names have changed."""
     random_string = get_random_line(10, include_punctuation=False)
-    sds_path = Path("/") / random_string
+    sds_path = PurePosixPath("/") / random_string
 
     # upload the file to sds
     uploaded_file = integration_client.upload_file(
@@ -455,7 +456,7 @@ def test_download_single_file(
     integration_client: Client, temp_file_with_text_contents: Path, tmp_path: Path
 ) -> None:
     """Test file download from SDS."""
-    sds_path = Path("/")
+    sds_path = PurePosixPath("/")
 
     # upload a test file
     uploaded_file = integration_client.upload_file(
@@ -498,7 +499,7 @@ def test_download_files_in_bulk(
 ) -> None:
     """Test downloading multiple files from SDS."""
     random_subdir_name = get_random_line(10, include_punctuation=False)
-    sds_path = Path("/test-tree") / random_subdir_name
+    sds_path = PurePosixPath("/test-tree") / random_subdir_name
     results = integration_client.upload(
         local_path=temp_file_tree,
         sds_path=sds_path,
@@ -584,7 +585,7 @@ def test_download_files_in_bulk(
 def test_file_listing(integration_client: Client, temp_file_tree: Path) -> None:
     """Tests listing files in a directory on SDS."""
     random_subdir_name = get_random_line(10, include_punctuation=False)
-    sds_path = Path("/test-tree") / random_subdir_name
+    sds_path = PurePosixPath("/test-tree") / random_subdir_name
     results = integration_client.upload(
         local_path=temp_file_tree,
         sds_path=sds_path,

--- a/sdk/tests/models/test_files.py
+++ b/sdk/tests/models/test_files.py
@@ -4,7 +4,7 @@
 
 from datetime import datetime
 from datetime import timedelta
-from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any
 
 import pytest
@@ -22,7 +22,7 @@ def file_properties() -> dict[str, Any]:
     tz = timezone("UTC")
     return {
         "name": "test_file",
-        "directory": Path("/my/files/are/here"),
+        "directory": PurePosixPath("/my/files/are/here"),
         "media_type": "text/plain",
         "permissions": "-w-rw-r--",
         "size": 111_222_333,
@@ -48,7 +48,7 @@ def test_file_path(file_properties: dict[str, Any]) -> None:
     new_file = File(
         **file_properties,
     )
-    assert new_file.path == Path(file_properties["directory"]) / file_properties["name"]
+    assert new_file.path == file_properties["directory"] / file_properties["name"]
 
 
 def test_chmod_props(file_properties: dict[str, Any]) -> None:

--- a/sdk/tests/ops/test_files.py
+++ b/sdk/tests/ops/test_files.py
@@ -60,6 +60,26 @@ def test_get_file_permissions(temp_file_empty: Path) -> None:
         assert get_file_permissions(temp_file_empty) == perm_string
 
 
+@pytest.mark.win32
+def test_get_file_permissions_win32(temp_file_empty: Path) -> None:
+    """
+    Test get_file_permissions for many permission combinations.
+
+    Windows only allows setting read or write permissions on a file.
+    """
+    chmod_combos = {
+        "r--r--r--": 0o400,
+        "r--r--r--": 0o440,  # noqa: F601
+        "r--r--r--": 0o444,  # noqa: F601
+        "rw-rw-rw-": 0o600,
+        "rw-rw-rw-": 0o660,  # noqa: F601
+        "rw-rw-rw-": 0o666,  # noqa: F601
+    }
+    for perm_string, chmod in chmod_combos.items():
+        temp_file_empty.chmod(chmod)
+        assert get_file_permissions(temp_file_empty) == perm_string
+
+
 def test_get_file_by_id(client: Client, responses: responses.RequestsMock) -> None:
     """Given a file ID, the client must return the file."""
     uuid = uuidlib.uuid4()

--- a/sdk/tests/ops/test_files.py
+++ b/sdk/tests/ops/test_files.py
@@ -7,6 +7,7 @@ import uuid as uuidlib
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 import responses
 from loguru import logger as log
 from spectrumx import Client
@@ -39,6 +40,8 @@ def _get_content_check_endpoint(client: Client) -> str:
     )
 
 
+@pytest.mark.linux
+@pytest.mark.darwin
 def test_get_file_permissions(temp_file_empty: Path) -> None:
     """Test get_file_permissions for many permission combinations."""
     chmod_combos = {

--- a/sdk/tests/ops/test_files.py
+++ b/sdk/tests/ops/test_files.py
@@ -113,7 +113,7 @@ def test_file_get_returns_valid(
 
 
 def test_file_upload_returns_file(
-    client: Client, temp_file_with_text_contents: Path
+    client: Client, temp_file_with_text_contents: Path, tmp_path: Path
 ) -> None:
     """The upload_file method must return a valid File instance."""
     test_file_size = temp_file_with_text_contents.stat().st_size
@@ -133,9 +133,9 @@ def test_file_upload_returns_file(
     assert file_sample.name is not None, "Expected a file name"
     assert file_sample.media_type == "text/plain", "Expected media type 'text/plain'"
     assert file_sample.size == test_file_size, "Expected the test file to be 4030 bytes"
-    assert "/tmp/pytest-" in str(  # noqa: S108
-        file_sample.local_path
-    ), "Expected the temp file directory"
+    assert str(tmp_path) in str(file_sample.local_path), (
+        "Expected the temp file directory"
+    )
     assert file_sample.directory == Path("/my/upload/location")
     assert file_sample.permissions == "rw-r--r--"
     assert isinstance(file_sample.created_at, datetime)

--- a/sdk/tests/test_client.py
+++ b/sdk/tests/test_client.py
@@ -3,6 +3,7 @@
 import re
 from enum import IntEnum
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any
 from unittest.mock import patch
 
@@ -140,7 +141,7 @@ def test_download_fails_for_invalid_files(
     """Ensures download() fails when an invalid local path is provided."""
 
     caplog.set_level(LogLevels.ERROR)
-    sds_path = Path("sds/custom/dir/")
+    sds_path = PurePosixPath("sds/custom/dir/")
     local_path = Path("local/path")
 
     target_num_files = 2

--- a/sdk/tests/test_usage.py
+++ b/sdk/tests/test_usage.py
@@ -6,6 +6,7 @@ Find asset-specific tests in `./ops/`.
 
 import uuid as uuidlib
 from pathlib import Path
+from pathlib import PurePosixPath
 
 import pytest
 from loguru import logger as log
@@ -117,7 +118,7 @@ def test_dry_file_upload_does_not_request(
     assert client.dry_run is True, "Dry run must be enabled for this test."
     _file_sample = client.upload_file(
         local_file=temp_file_with_text_contents,
-        sds_path=Path("/my/upload/location"),
+        sds_path=PurePosixPath("/my/upload/location"),
     )
 
 

--- a/sdk/tests/test_utils.py
+++ b/sdk/tests/test_utils.py
@@ -77,6 +77,8 @@ def test_into_bool_truthy() -> None:
         assert utils.into_human_bool(truthy) is True, f"{truthy} failed"
 
 
+@pytest.mark.linux
+@pytest.mark.darwin
 def test_clean_local_path() -> None:
     """Test that a local path is cleaned."""
     test_cases = [


### PR DESCRIPTION
This PR fixes issues with the SDK on windows and includes the changes in #71.

It replaces the use of Paths with PurePosixPaths for the SDS paths as the server side paths should all use forward slash directory separators.  The tests are all updated to use this.

It also introduces YARL as a dependency for handling URLs as Path alone was introducing some URL Encoded characters breaking the calls to the endpoints. I could try rearranging the commits to verify if the YARL dependency is required now that I have cleaned everything up.