### PR TITLE
Capture Searching with OpenSearch Queries

### DIFF
--- a/gateway/sds_gateway/api_methods/helpers/search_captures.py
+++ b/gateway/sds_gateway/api_methods/helpers/search_captures.py
@@ -1,0 +1,153 @@
+"""Helper functions for searching captures with metadata filtering."""
+
+import logging
+from typing import Any
+
+from django.db.models import QuerySet
+from opensearchpy import exceptions as os_exceptions
+
+from sds_gateway.api_methods.models import Capture
+from sds_gateway.api_methods.utils.metadata_schemas import (
+    capture_metadata_fields_by_type,
+)
+from sds_gateway.api_methods.utils.opensearch_client import get_opensearch_client
+
+logger = logging.getLogger(__name__)
+
+RangeValue = dict[str, int | float]
+UNKNOWN_CAPTURE_TYPE = "Unknown capture type"
+
+
+def build_metadata_query(
+    capture_type: str,
+    metadata_filters: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Build OpenSearch query for metadata fields.
+
+    Args:
+        capture_type: Type of capture (e.g. 'drf')
+        metadata_filters: Dictionary of metadata field names and their filter values.
+            For range queries on supported fields, value should be a dict with
+            'gte'/'lte' keys.
+            Example: {"center_freq": {"gte": 1000000, "lte": 2000000}}
+
+    Returns:
+        List of OpenSearch query clauses for the metadata fields
+    """
+    schema = capture_metadata_fields_by_type.get(capture_type, {})
+
+    # Get the properties and index mapping for this capture type
+    properties = schema.get("properties", {})
+    index_mapping = schema.get("index_mapping", {})
+
+    # Build metadata query
+    metadata_queries = []
+    for field, value in metadata_filters.items():
+        # Skip if field is not in index mapping
+        if field not in index_mapping:
+            continue
+
+        field_config = properties.get(field, {})
+        field_path = f"metadata.{field}"
+
+        # Handle range queries for supported fields
+        if field_config.get("supports_range") and isinstance(value, dict):
+            range_query: RangeValue = {}
+            if "gte" in value:
+                range_query["gte"] = value["gte"]
+            if "lte" in value:
+                range_query["lte"] = value["lte"]
+            if range_query:
+                metadata_queries.append({"range": {field_path: range_query}})
+        else:
+            # Regular exact match query
+            metadata_queries.append({"match": {field_path: value}})
+
+    return metadata_queries
+
+
+def search_captures(
+    user,
+    capture_type: str | None = None,
+    metadata_filters: dict[str, Any] | None = None,
+) -> QuerySet[Capture]:
+    """Search for captures with optional metadata filtering.
+
+    Args:
+        user: User to filter captures by ownership (required)
+        capture_type: Optional type of capture to filter by (e.g. 'drf')
+        metadata_filters: Optional dict of metadata field names and their filter values
+
+    Returns:
+        QuerySet of Capture objects matching the criteria
+
+    Raises:
+        ValueError: If the capture type is invalid
+    """
+    # Start with base queryset filtered by user
+    captures = Capture.objects.filter(owner=user)
+
+    # Filter by capture type if provided
+    if capture_type:
+        # Verify capture type exists before filtering
+        if not capture_metadata_fields_by_type.get(capture_type):
+            raise ValueError(UNKNOWN_CAPTURE_TYPE)
+        captures = captures.filter(capture_type=capture_type)
+
+    # If no metadata filters, return all matching captures
+    if not metadata_filters or not capture_type:
+        return captures
+
+    # Build metadata query
+    metadata_queries = build_metadata_query(capture_type, metadata_filters)
+    if not metadata_queries:
+        return captures
+
+    # Build the full query with both capture_type and metadata filters
+    query = {
+        "query": {
+            "bool": {
+                "must": [
+                    {"term": {"capture_type": capture_type}},
+                    *metadata_queries,
+                ],
+            },
+        },
+    }
+
+    # Search OpenSearch
+    client = get_opensearch_client()
+    index_name = f"captures-{capture_type}"
+
+    try:
+        response = client.search(
+            index=index_name,
+            body=query,
+        )
+        # Get UUIDs of matching documents
+        matching_uuids = [hit["_id"] for hit in response["hits"]["hits"]]
+        # Filter captures by matching UUIDs
+        return captures.filter(uuid__in=matching_uuids)
+    except os_exceptions.NotFoundError as err:
+        # Log the error
+        msg = f"Index '{index_name}' not found"
+        logger.exception(msg)
+        raise ValueError(msg) from err
+    except os_exceptions.ConnectionError as e:
+        # Log the error
+        msg = f"Failed to connect to OpenSearch: {e}"
+        logger.exception(msg)
+        # Handle the error (e.g., retry, raise an exception, etc.)
+        raise
+    except os_exceptions.RequestError as e:
+        # Log the error
+        msg = f"OpenSearch query error: {e}"
+        logger.exception(msg)
+        # Handle the error (e.g., retry, raise an exception, etc.)
+        raise
+    except os_exceptions.OpenSearchException as e:
+        # Log the error
+        msg = f"OpenSearch error: {e}"
+        logger.exception(msg)
+        # Handle the error (e.g., retry, raise an exception, etc.)
+        raise

--- a/gateway/sds_gateway/api_methods/helpers/search_captures.py
+++ b/gateway/sds_gateway/api_methods/helpers/search_captures.py
@@ -97,7 +97,9 @@ def build_metadata_query(
     # Build metadata query
     metadata_queries = []
     for query in metadata_filters:
-        field_path = query["field"]
+        field_path = query["field_path"]
+        query_type = query["query_type"]
+        filter_value = query["filter_value"]
 
         # warn if the field is not in the index mapping
         # but continue to build the query
@@ -113,13 +115,13 @@ def build_metadata_query(
             metadata_queries.append(
                 handle_nested_query(
                     field_path,
-                    query["type"],
-                    query["value"],
+                    query_type,
+                    filter_value,
                     levels_nested,
                 )
             )
         else:
-            metadata_queries.append({query["type"]: {field_path: query["value"]}})
+            metadata_queries.append({query_type: {field_path: filter_value}})
 
     return metadata_queries
 

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -395,9 +395,9 @@ class CaptureTestCases(APITestCase):
         center_freq = 2000000000
         metadata_filters = [
             {
-                "field": "capture_props.center_freq",
-                "type": "match",
-                "value": center_freq,
+                "field_path": "capture_props.center_freq",
+                "query_type": "match",
+                "filter_value": center_freq,
             },
         ]
         response = self.client.get(
@@ -420,9 +420,9 @@ class CaptureTestCases(APITestCase):
         center_freq = 2000000000
         metadata_filters = [
             {
-                "field": "capture_props.metadata.fmax",
-                "type": "range",
-                "value": {
+                "field_path": "capture_props.metadata.fmax",
+                "query_type": "range",
+                "filter_value": {
                     "gt": center_freq,
                 },
             },
@@ -449,9 +449,9 @@ class CaptureTestCases(APITestCase):
         bottom_right_lon = -85
         metadata_filters = [
             {
-                "field": "capture_props.coordinates",
-                "type": "geo_bounding_box",
-                "value": {
+                "field_path": "capture_props.coordinates",
+                "query_type": "geo_bounding_box",
+                "filter_value": {
                     "top_left": {
                         "lat": top_left_lat,
                         "lon": top_left_lon,

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -1,6 +1,7 @@
 """Tests for capture endpoints."""
 
 import datetime
+import json
 import logging
 import uuid
 from typing import cast
@@ -383,6 +384,24 @@ class CaptureTestCases(APITestCase):
         self.opensearch.indices.refresh(index=self.drf_capture.index_name)
         response = self.client.get(self.list_url)
         assert response.status_code == status.HTTP_200_OK
+
+    def test_list_captures_with_metadata_filters_200(self) -> None:
+        """Test listing captures with metadata filters returns correct captures."""
+        center_freq = 2000000000
+        metadata_filters = [
+            {
+                "field": "capture_props.center_freq",
+                "type": "match",
+                "value": center_freq,
+            },
+        ]
+        response = self.client.get(
+            f"{self.list_url}?metadata_filters={json.dumps(metadata_filters)}"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["capture_props"]["center_freq"] == center_freq
 
     def test_retrieve_capture_200(self) -> None:
         """Test retrieving a single capture returns full metadata."""

--- a/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
+++ b/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
@@ -179,72 +179,6 @@ drf_capture_index_mapping = {
     },
 }
 
-drf_index_search_params = {
-    "sample_rate_numerator": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "sample_rate_denominator": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "samples_per_second": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "start_bound": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "end_bound": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "center_freq": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "span": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "gain": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "bandwidth": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-}
-
 # for full schema definition, see https://github.com/spectrumx/schema-definitions/blob/master/definitions/sds/metadata-formats/radiohound/v0/schema.json
 # full mapping is not used in this repo, but is provided here for reference
 rh_capture_index_mapping = {
@@ -291,77 +225,13 @@ rh_capture_index_mapping = {
     },
 }
 
-rh_index_search_params = {
-    "metadata.fmax": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "metadata.fmin": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "metadata.nfft": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "sample_rate": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "center_frequency": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "coordinates": {
-        "accept": [
-            "match",
-            "multi_match",
-            "geo_distance",
-            "geo_bounding_box",
-        ],
-    },
-    "altitude": {
-        "accept": [
-            "match",
-            "multi_match",
-            "range",
-        ],
-    },
-    "mac_address": {
-        "accept": [
-            "match",
-            "match_phrase",
-            "multi_match",
-        ],
-    },
-    "short_name": {
-        "accept": [
-            "match",
-            "match_phrase",
-            "multi_match",
-        ],
-    },
-}
-
-rh_index_search_params_by_type = {
-    "drf": drf_index_search_params,
-    "rh": rh_index_search_params,
-}
+base_index_fields = [
+    "channel",
+    "scan_group",
+    "capture_type",
+    "created_at",
+    "capture_props",
+]
 
 capture_index_mapping_by_type = {
     "drf": drf_capture_index_mapping,

--- a/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
+++ b/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
@@ -217,6 +217,9 @@ rh_capture_index_mapping = {
     "coordinates": {
         "type": "geo_point",
     },
+    "altitude": {
+        "type": "float",
+    },
     "mac_address": {
         "type": "keyword",
     },

--- a/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
+++ b/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
@@ -179,11 +179,100 @@ drf_capture_index_mapping = {
     },
 }
 
+drf_index_search_params = {
+    "sample_rate_numerator": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "sample_rate_denominator": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "samples_per_second": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "start_bound": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "end_bound": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "center_freq": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "span": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "gain": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "bandwidth": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+}
+
 # for full schema definition, see https://github.com/spectrumx/schema-definitions/blob/master/definitions/sds/metadata-formats/radiohound/v0/schema.json
 # full mapping is not used in this repo, but is provided here for reference
 rh_capture_index_mapping = {
     "metadata": {
         "type": "nested",
+        "properties": {
+            "archive_result": {
+                "type": "boolean",
+            },
+            "data_type": {
+                "type": "keyword",
+            },
+            "fmax": {
+                "type": "float",
+            },
+            "fmin": {
+                "type": "float",
+            },
+            "gps_lock": {
+                "type": "boolean",
+            },
+            "nfft": {
+                "type": "integer",
+            },
+            "scan_time": {
+                "type": "float",
+            },
+        },
     },
     "sample_rate": {
         "type": "integer",
@@ -191,14 +280,8 @@ rh_capture_index_mapping = {
     "center_frequency": {
         "type": "float",
     },
-    "latitude": {
-        "type": "float",
-    },
-    "longitude": {
-        "type": "float",
-    },
-    "altitude": {
-        "type": "float",
+    "coordinates": {
+        "type": "geo_point",
     },
     "mac_address": {
         "type": "keyword",
@@ -206,6 +289,78 @@ rh_capture_index_mapping = {
     "short_name": {
         "type": "text",
     },
+}
+
+rh_index_search_params = {
+    "metadata.fmax": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "metadata.fmin": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "metadata.nfft": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "sample_rate": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "center_frequency": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "coordinates": {
+        "accept": [
+            "match",
+            "multi_match",
+            "geo_distance",
+            "geo_bounding_box",
+        ],
+    },
+    "altitude": {
+        "accept": [
+            "match",
+            "multi_match",
+            "range",
+        ],
+    },
+    "mac_address": {
+        "accept": [
+            "match",
+            "match_phrase",
+            "multi_match",
+        ],
+    },
+    "short_name": {
+        "accept": [
+            "match",
+            "match_phrase",
+            "multi_match",
+        ],
+    },
+}
+
+rh_index_search_params_by_type = {
+    "drf": drf_index_search_params,
+    "rh": rh_index_search_params,
 }
 
 capture_index_mapping_by_type = {

--- a/gateway/sds_gateway/api_methods/utils/swagger_example_schema.py
+++ b/gateway/sds_gateway/api_methods/utils/swagger_example_schema.py
@@ -272,9 +272,10 @@ example_file_content_check_request = {
 }
 
 capture_list_request_example_schema = {
+    "capture_type": CaptureType.DigitalRF,
     "metadata_filters": {
-        "start_bound": {"$gte": 1515000000},
-        "end_bound": {"$lte": 1515005000},
+        "start_bound": {"gte": 1515000000},
+        "end_bound": {"lte": 1515005000},
     },
 }
 
@@ -282,5 +283,9 @@ capture_list_response_example_schema = {
     "count": 105,
     "next": "http://localhost:8000/api/latest/assets/captures/?page=2&page_size=3",
     "previous": None,
-    "results": [],
+    "results": [
+        capture_response_example_schema,
+        capture_response_example_schema,
+        capture_response_example_schema,
+    ],
 }

--- a/gateway/sds_gateway/api_methods/utils/swagger_example_schema.py
+++ b/gateway/sds_gateway/api_methods/utils/swagger_example_schema.py
@@ -273,12 +273,56 @@ example_file_content_check_request = {
 
 capture_list_request_example_schema = {
     "capture_type": CaptureType.DigitalRF,
-    "metadata_filters": {
-        "start_bound": {"gte": 1515000000},
-        "end_bound": {"lte": 1515005000},
-    },
+    "metadata_filters": [
+        {
+            "field": "capture_props.start_bound",
+            "query_type": "range",
+            "filter_value": {
+                "gte": 1515000000,
+            },
+        },
+        {
+            "field": "capture_props.end_bound",
+            "query_type": "range",
+            "filter_value": {
+                "lte": 1515005000,
+            },
+        },
+        {
+            "field": "capture_props.center_freq",
+            "query_type": "match",
+            "filter_value": 1024000000,
+        },
+    ],
 }
 
+capture_response_example_schema = {
+    "uuid": "2c413fbb-4132-4d56-a0c0-633acdd71676",
+    "owner": {
+        "id": 1,
+        "email": "user@example.com",
+        "name": "",
+    },
+    "capture_props": {
+        "start_bound": 1515000000,
+        "end_bound": 1515005000,
+        "center_freq": 1024000000,
+    },
+    "files": [
+        {
+            "uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "name": "file.h5",
+            "directory": "/files/user@example.com/path/to/file",
+        },
+    ],
+    "created_at": "2025-03-05T12:23:26.229351-05:00",
+    "updated_at": "2025-03-05T12:23:26.229368-05:00",
+    "deleted_at": None,
+    "is_deleted": False,
+    "channel": "fm_n",
+    "scan_group": None,
+    "capture_type": "drf",
+}
 capture_list_response_example_schema = {
     "count": 105,
     "next": "http://localhost:8000/api/latest/assets/captures/?page=2&page_size=3",

--- a/gateway/sds_gateway/api_methods/utils/swagger_example_schema.py
+++ b/gateway/sds_gateway/api_methods/utils/swagger_example_schema.py
@@ -270,3 +270,17 @@ example_file_content_check_request = {
     "permissions": "rw-r--r--",
     "sum_blake3": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
 }
+
+capture_list_request_example_schema = {
+    "metadata_filters": {
+        "start_bound": {"$gte": 1515000000},
+        "end_bound": {"$lte": 1515005000},
+    },
+}
+
+capture_list_response_example_schema = {
+    "count": 105,
+    "next": "http://localhost:8000/api/latest/assets/captures/?page=2&page_size=3",
+    "previous": None,
+    "results": [],
+}

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -279,6 +279,13 @@ class CaptureViewSet(viewsets.ViewSet):
                 required=False,
                 description="Type of capture to filter by (e.g. 'drf')",
             ),
+            OpenApiParameter(
+                name="metadata_filters",
+                type=OpenApiTypes.JSON,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="Metadata filters to apply to the search",
+            ),
         ],
         responses={
             200: CaptureGetSerializer,
@@ -286,6 +293,20 @@ class CaptureViewSet(viewsets.ViewSet):
             503: OpenApiResponse(description="OpenSearch service unavailable"),
             400: OpenApiResponse(description="Bad Request"),
         },
+        examples=[
+            OpenApiExample(
+                "Example Capture List Request",
+                summary="Capture List Request Body",
+                value=example_schema.capture_list_request_example_schema,
+                request_only=True,
+            ),
+            OpenApiExample(
+                "Example Capture List Response",
+                summary="Capture List Response Body",
+                value=example_schema.capture_list_response_example_schema,
+                response_only=True,
+            ),
+        ],
         description="List captures with optional metadata filtering.",
         summary="List Captures",
     )

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -398,13 +398,24 @@ class CaptureViewSet(viewsets.ViewSet):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         except os_exceptions.ConnectionError as err:
-            log.exception(err)
+            try:
+                log.exception(err)
+            except Exception:  # noqa: BLE001
+                # used in tests when mocking this exception
+                log.error("OpenSearch connection error")
             return Response(
                 {"detail": "Internal service unavailable"},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
-        except (os_exceptions.RequestError, os_exceptions.OpenSearchException) as err:
-            log.exception(err)
+        except (
+            os_exceptions.RequestError,
+            os_exceptions.OpenSearchException,
+        ) as err:
+            try:
+                log.exception(err)
+            except Exception:  # noqa: BLE001
+                # used in tests when mocking this exception
+                log.error(str(err))
             return Response(
                 {"detail": "Internal server error"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -328,7 +328,7 @@ class CaptureViewSet(viewsets.ViewSet):
             ),
             OpenApiParameter(
                 name="metadata_filters",
-                type=OpenApiTypes.JSON,
+                type=OpenApiTypes.OBJECT,
                 location=OpenApiParameter.QUERY,
                 required=False,
                 description="Metadata filters to apply to the search",

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -80,7 +80,17 @@ class CaptureViewSet(viewsets.ViewSet):
             case CaptureType.RadioHound:
                 rh_metadata_file = find_rh_metadata_file(data_path)
                 rh_data = load_rh_file(rh_metadata_file)
-                capture_props = rh_data.model_dump(mode="json")
+                rh_json = rh_data.model_dump(mode="json")
+
+                # replace "latitude" and "longitude" in the json with coordinates
+                rh_json["coordinates"] = {
+                    "lat": rh_json["latitude"],
+                    "lon": rh_json["longitude"],
+                }
+                del rh_json["latitude"]
+                del rh_json["longitude"]
+
+                capture_props = rh_json
             case _:
                 msg = f"Unrecognized capture type '{cap_type}'"
                 log.warning(msg)


### PR DESCRIPTION
For the search functionality, I decided to allow for more versatility on the part of the user to make queries with any degree of complexity that they choose, so the API accepts `metadata_filters` as a list of dictionaries that include the field path (for handling nested fields, or just the name if it is not nested, any `capture_props` field is nested under `"capture_props.<field_name>"`), the query type (from OpenSearch DSL), and the filter value (structured according to the DSL).

I provided some documentation in the README to provide examples of what the request filters might look like for users and a link to the OpenSearch Query DSL docs: https://opensearch.org/docs/latest/query-dsl/