### PR TITLE
Bug fix for "sibling" file uploads

### DIFF
--- a/sdk/tests/integration/test_file_ops.py
+++ b/sdk/tests/integration/test_file_ops.py
@@ -56,9 +56,9 @@ def test_is_valid_file_disallowed(temp_file_with_text_contents) -> None:
     for mime_type in disallowed_mime_types:
         with patch("spectrumx.ops.files.get_file_media_type", return_value=mime_type):
             is_valid, reasons = is_valid_file(temp_file_with_text_contents)
-            assert not is_valid, (
-                f"File with MIME type {mime_type} should be disallowed."
-            )
+            assert (
+                not is_valid
+            ), f"File with MIME type {mime_type} should be disallowed."
             assert reasons, "Reasons should be given for disallowed files."
 
 
@@ -78,9 +78,9 @@ def test_get_valid_files(temp_file_tree: Path) -> None:
 
     # all test files should be valid and match the local path
     invalid_file_paths = all_file_paths - valid_file_paths
-    assert invalid_file_paths == set(), (
-        f"All files should be valid. Invalid paths: {invalid_file_paths}"
-    )
+    assert (
+        invalid_file_paths == set()
+    ), f"All files should be valid. Invalid paths: {invalid_file_paths}"
 
 
 @pytest.mark.integration
@@ -184,12 +184,12 @@ def test_upload_large_file(
     assert uploaded_file is not None, "File upload failed."
     assert isinstance(uploaded_file.uuid, uuid.UUID), "UUID not set."
     assert uploaded_file.size == local_file.size, "Size mismatch."
-    assert len(uploaded_file.compute_sum_blake3() or "") == BLAKE3_HEX_LEN, (
-        "Checksum not set."
-    )
-    assert uploaded_file.compute_sum_blake3() == local_file.compute_sum_blake3(), (
-        "Checksum mismatch."
-    )
+    assert (
+        len(uploaded_file.compute_sum_blake3() or "") == BLAKE3_HEX_LEN
+    ), "Checksum not set."
+    assert (
+        uploaded_file.compute_sum_blake3() == local_file.compute_sum_blake3()
+    ), "Checksum mismatch."
 
 
 @pytest.mark.integration
@@ -218,18 +218,18 @@ def test_check_file_content_non_existing(
     file_contents_check = integration_client._gateway.check_file_contents_exist(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         file_instance
     )
-    assert file_contents_check.file_contents_exist_for_user is False, (
-        "Test file shouldn't exist for user."
-    )
-    assert file_contents_check.file_exists_in_tree is False, (
-        "Test file shouldn't exist in tree."
-    )
-    assert file_contents_check.user_mutable_attributes_differ is True, (
-        "Attributes should always differ for non-existent files."
-    )
-    assert file_contents_check.asset_id is None, (
-        "Asset ID should be None for non-existent files."
-    )
+    assert (
+        file_contents_check.file_contents_exist_for_user is False
+    ), "Test file shouldn't exist for user."
+    assert (
+        file_contents_check.file_exists_in_tree is False
+    ), "Test file shouldn't exist in tree."
+    assert (
+        file_contents_check.user_mutable_attributes_differ is True
+    ), "Attributes should always differ for non-existent files."
+    assert (
+        file_contents_check.asset_id is None
+    ), "Asset ID should be None for non-existent files."
 
 
 @pytest.mark.integration
@@ -265,15 +265,15 @@ def test_check_file_content_identical(
     file_contents_check = integration_client._gateway.check_file_contents_exist(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         file_instance
     )
-    assert file_contents_check.file_contents_exist_for_user is True, (
-        "Test file should exist for user."
-    )
-    assert file_contents_check.file_exists_in_tree is True, (
-        "Test file should exist in tree."
-    )
-    assert file_contents_check.user_mutable_attributes_differ is False, (
-        "Attributes should be identical."
-    )
+    assert (
+        file_contents_check.file_contents_exist_for_user is True
+    ), "Test file should exist for user."
+    assert (
+        file_contents_check.file_exists_in_tree is True
+    ), "Test file should exist in tree."
+    assert (
+        file_contents_check.user_mutable_attributes_differ is False
+    ), "Attributes should be identical."
     assert file_contents_check.asset_id == uploaded_file.uuid, (
         "Asset ID does not match uploaded file: "
         f"{file_contents_check.asset_id} != {uploaded_file.uuid!s}"
@@ -320,15 +320,15 @@ def test_check_file_content_name_changed(
     file_contents_check = integration_client._gateway.check_file_contents_exist(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         file_instance_renamed
     )
-    assert file_contents_check.file_exists_in_tree is False, (
-        "Test file shouldn't be identical to the one in SDS anymore."
-    )
-    assert file_contents_check.file_contents_exist_for_user is True, (
-        "Test file contents should exist for this user, under a different name."
-    )
-    assert file_contents_check.user_mutable_attributes_differ is True, (
-        "Attributes are different (name)."
-    )
+    assert (
+        file_contents_check.file_exists_in_tree is False
+    ), "Test file shouldn't be identical to the one in SDS anymore."
+    assert (
+        file_contents_check.file_contents_exist_for_user is True
+    ), "Test file contents should exist for this user, under a different name."
+    assert (
+        file_contents_check.user_mutable_attributes_differ is True
+    ), "Attributes are different (name)."
     assert file_contents_check.asset_id == uploaded_file.uuid, (
         "Expected asset ID to be the closest match (sibling UUID) to the uploaded file:"
         f"{file_contents_check.asset_id} != {uploaded_file.uuid!s}"
@@ -432,9 +432,9 @@ def test_download_files_in_bulk(
     # sort downloaded_files and uploaded_files by uuid
     downloaded_files = sorted(downloaded_files, key=lambda f: f.uuid or "-")
     uploaded_files = sorted(uploaded_files, key=lambda f: f.uuid or "-")
-    assert len(downloaded_files) == len(uploaded_files), (
-        "Number of downloaded files does not match the number of uploaded files."
-    )
+    assert len(downloaded_files) == len(
+        uploaded_files
+    ), "Number of downloaded files does not match the number of uploaded files."
 
     for uploaded_file, downloaded_file in zip(
         uploaded_files, downloaded_files, strict=True
@@ -453,14 +453,14 @@ def test_download_files_in_bulk(
         assert upload_path.is_file(), "Downloaded file not found."
 
         # they must be different
-        assert upload_path != download_path, (
-            "Uploaded and downloaded file path should be different."
-        )
+        assert (
+            upload_path != download_path
+        ), "Uploaded and downloaded file path should be different."
 
         # check contents are the same
-        assert downloaded_file.is_same_contents(uploaded_file, verbose=True), (
-            f"Contents mismatch for file {uploaded_file.path.name}"
-        )
+        assert downloaded_file.is_same_contents(
+            uploaded_file, verbose=True
+        ), f"Contents mismatch for file {uploaded_file.path.name}"
 
         # assert downloaded path is a child of the download_dir
         assert download_path.is_relative_to(download_dir), (

--- a/sdk/tests/integration/test_file_ops.py
+++ b/sdk/tests/integration/test_file_ops.py
@@ -56,9 +56,9 @@ def test_is_valid_file_disallowed(temp_file_with_text_contents) -> None:
     for mime_type in disallowed_mime_types:
         with patch("spectrumx.ops.files.get_file_media_type", return_value=mime_type):
             is_valid, reasons = is_valid_file(temp_file_with_text_contents)
-            assert (
-                not is_valid
-            ), f"File with MIME type {mime_type} should be disallowed."
+            assert not is_valid, (
+                f"File with MIME type {mime_type} should be disallowed."
+            )
             assert reasons, "Reasons should be given for disallowed files."
 
 
@@ -78,9 +78,9 @@ def test_get_valid_files(temp_file_tree: Path) -> None:
 
     # all test files should be valid and match the local path
     invalid_file_paths = all_file_paths - valid_file_paths
-    assert (
-        invalid_file_paths == set()
-    ), f"All files should be valid. Invalid paths: {invalid_file_paths}"
+    assert invalid_file_paths == set(), (
+        f"All files should be valid. Invalid paths: {invalid_file_paths}"
+    )
 
 
 @pytest.mark.integration
@@ -116,6 +116,101 @@ def test_upload_single_file(
     )
     assert uploaded_file.compute_sum_blake3() == local_file.compute_sum_blake3(), (
         "Checksum mismatch."
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("_integration_setup_teardown")
+@pytest.mark.usefixtures("_without_responses")
+@pytest.mark.parametrize(
+    "_without_responses",
+    argvalues=[
+        [
+            *PassthruEndpoints.file_content_checks(),
+            *PassthruEndpoints.file_uploads(),
+        ]
+    ],
+    indirect=True,
+)
+def test_upload_sibling(
+    integration_client: Client, temp_file_with_text_contents: Path
+) -> None:
+    """Tests the sibling file upload (when file contents are already in the server)."""
+    sds_path = Path("/")
+
+    # create a copy of the temp file with text contents
+    temp_file_copy = temp_file_with_text_contents.with_name(
+        f"{temp_file_with_text_contents.stem}_COPY_{temp_file_with_text_contents.suffix}"
+    )
+    temp_file_copy.write_text(temp_file_with_text_contents.read_text())
+    assert temp_file_copy.exists(), "Copy of the file should exist."
+    assert temp_file_copy.is_file(), "Copy of the file should be a file."
+    assert (
+        temp_file_copy.stat().st_size == temp_file_with_text_contents.stat().st_size
+    ), (
+        "Copy of the file should have the same size as the original."
+        f"{temp_file_copy.stat().st_size} != "
+        "{temp_file_with_text_contents.stat().st_size}"
+    )
+    original_file = construct_file(temp_file_with_text_contents, sds_path=sds_path)
+    copied_file = construct_file(temp_file_copy, sds_path=sds_path)
+
+    # pre-conditions for test
+    assert original_file.name != copied_file.name, "File names should be different."
+    assert original_file.compute_sum_blake3() == copied_file.compute_sum_blake3(), (
+        "Original and copied files should have the same checksum."
+        f"{original_file.compute_sum_blake3()} != {copied_file.compute_sum_blake3()}"
+    )
+
+    # upload original file
+    original_upload = integration_client.upload_file(
+        local_file=temp_file_with_text_contents, sds_path=sds_path
+    )
+
+    # assertions of the original upload
+    assert original_upload.local_path is not None, "Local path not set for original."
+    assert original_upload.is_sample is False, "Sample file returned."
+    for attr in original_upload.__dict__:
+        log.debug(f"\t{attr:>15} = {original_upload.__dict__[attr]}")
+    assert original_upload is not None, "File upload failed."
+    assert isinstance(original_upload.uuid, uuid.UUID), "UUID not set."
+    assert original_upload.size == original_file.size, "Size mismatch."
+    assert original_upload.directory == original_file.directory, (
+        "Directory should be the same."
+        f"{original_upload.directory} != {original_file.directory}"
+    )
+    assert original_upload.name == original_file.name, (
+        f"File names should be the same.{original_upload.name} != {original_file.name}"
+    )
+
+    # upload copy
+    copy_upload = integration_client.upload_file(
+        local_file=temp_file_copy, sds_path=sds_path
+    )
+
+    # assertions of the copy
+    assert copy_upload.local_path is not None, "Local path not set for copy."
+    assert copy_upload.is_sample is False, "Sample file returned."
+    for attr in copy_upload.__dict__:
+        log.debug(f"\t{attr:>15} = {copy_upload.__dict__[attr]}")
+    assert copy_upload is not None, "File upload failed."
+    assert isinstance(copy_upload.uuid, uuid.UUID), "UUID not set."
+    assert copy_upload.directory == copied_file.directory, (
+        "Directory should be the same."
+        f"{copy_upload.directory} != {copied_file.directory}"
+    )
+    assert copy_upload.name == copied_file.name, (
+        f"File names should be the same.{copy_upload.name} != {copied_file.name}"
+    )
+
+    # final assertions between files
+    assert copy_upload.size == copied_file.size, "Size mismatch."
+    assert copy_upload.compute_sum_blake3() == original_upload.compute_sum_blake3(), (
+        "Checksum mismatch."
+    )
+    assert copy_upload.uuid != original_upload.uuid, (
+        "UUIDs should NOT be the same for identical files."
+        f"{copy_upload.uuid} != {original_upload.uuid}"
     )
 
 
@@ -184,12 +279,12 @@ def test_upload_large_file(
     assert uploaded_file is not None, "File upload failed."
     assert isinstance(uploaded_file.uuid, uuid.UUID), "UUID not set."
     assert uploaded_file.size == local_file.size, "Size mismatch."
-    assert (
-        len(uploaded_file.compute_sum_blake3() or "") == BLAKE3_HEX_LEN
-    ), "Checksum not set."
-    assert (
-        uploaded_file.compute_sum_blake3() == local_file.compute_sum_blake3()
-    ), "Checksum mismatch."
+    assert len(uploaded_file.compute_sum_blake3() or "") == BLAKE3_HEX_LEN, (
+        "Checksum not set."
+    )
+    assert uploaded_file.compute_sum_blake3() == local_file.compute_sum_blake3(), (
+        "Checksum mismatch."
+    )
 
 
 @pytest.mark.integration
@@ -218,18 +313,18 @@ def test_check_file_content_non_existing(
     file_contents_check = integration_client._gateway.check_file_contents_exist(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         file_instance
     )
-    assert (
-        file_contents_check.file_contents_exist_for_user is False
-    ), "Test file shouldn't exist for user."
-    assert (
-        file_contents_check.file_exists_in_tree is False
-    ), "Test file shouldn't exist in tree."
-    assert (
-        file_contents_check.user_mutable_attributes_differ is True
-    ), "Attributes should always differ for non-existent files."
-    assert (
-        file_contents_check.asset_id is None
-    ), "Asset ID should be None for non-existent files."
+    assert file_contents_check.file_contents_exist_for_user is False, (
+        "Test file shouldn't exist for user."
+    )
+    assert file_contents_check.file_exists_in_tree is False, (
+        "Test file shouldn't exist in tree."
+    )
+    assert file_contents_check.user_mutable_attributes_differ is True, (
+        "Attributes should always differ for non-existent files."
+    )
+    assert file_contents_check.asset_id is None, (
+        "Asset ID should be None for non-existent files."
+    )
 
 
 @pytest.mark.integration
@@ -265,15 +360,15 @@ def test_check_file_content_identical(
     file_contents_check = integration_client._gateway.check_file_contents_exist(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         file_instance
     )
-    assert (
-        file_contents_check.file_contents_exist_for_user is True
-    ), "Test file should exist for user."
-    assert (
-        file_contents_check.file_exists_in_tree is True
-    ), "Test file should exist in tree."
-    assert (
-        file_contents_check.user_mutable_attributes_differ is False
-    ), "Attributes should be identical."
+    assert file_contents_check.file_contents_exist_for_user is True, (
+        "Test file should exist for user."
+    )
+    assert file_contents_check.file_exists_in_tree is True, (
+        "Test file should exist in tree."
+    )
+    assert file_contents_check.user_mutable_attributes_differ is False, (
+        "Attributes should be identical."
+    )
     assert file_contents_check.asset_id == uploaded_file.uuid, (
         "Asset ID does not match uploaded file: "
         f"{file_contents_check.asset_id} != {uploaded_file.uuid!s}"
@@ -320,15 +415,15 @@ def test_check_file_content_name_changed(
     file_contents_check = integration_client._gateway.check_file_contents_exist(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
         file_instance_renamed
     )
-    assert (
-        file_contents_check.file_exists_in_tree is False
-    ), "Test file shouldn't be identical to the one in SDS anymore."
-    assert (
-        file_contents_check.file_contents_exist_for_user is True
-    ), "Test file contents should exist for this user, under a different name."
-    assert (
-        file_contents_check.user_mutable_attributes_differ is True
-    ), "Attributes are different (name)."
+    assert file_contents_check.file_exists_in_tree is False, (
+        "Test file shouldn't be identical to the one in SDS anymore."
+    )
+    assert file_contents_check.file_contents_exist_for_user is True, (
+        "Test file contents should exist for this user, under a different name."
+    )
+    assert file_contents_check.user_mutable_attributes_differ is True, (
+        "Attributes are different (name)."
+    )
     assert file_contents_check.asset_id == uploaded_file.uuid, (
         "Expected asset ID to be the closest match (sibling UUID) to the uploaded file:"
         f"{file_contents_check.asset_id} != {uploaded_file.uuid!s}"
@@ -432,9 +527,9 @@ def test_download_files_in_bulk(
     # sort downloaded_files and uploaded_files by uuid
     downloaded_files = sorted(downloaded_files, key=lambda f: f.uuid or "-")
     uploaded_files = sorted(uploaded_files, key=lambda f: f.uuid or "-")
-    assert len(downloaded_files) == len(
-        uploaded_files
-    ), "Number of downloaded files does not match the number of uploaded files."
+    assert len(downloaded_files) == len(uploaded_files), (
+        "Number of downloaded files does not match the number of uploaded files."
+    )
 
     for uploaded_file, downloaded_file in zip(
         uploaded_files, downloaded_files, strict=True
@@ -453,14 +548,14 @@ def test_download_files_in_bulk(
         assert upload_path.is_file(), "Downloaded file not found."
 
         # they must be different
-        assert (
-            upload_path != download_path
-        ), "Uploaded and downloaded file path should be different."
+        assert upload_path != download_path, (
+            "Uploaded and downloaded file path should be different."
+        )
 
         # check contents are the same
-        assert downloaded_file.is_same_contents(
-            uploaded_file, verbose=True
-        ), f"Contents mismatch for file {uploaded_file.path.name}"
+        assert downloaded_file.is_same_contents(uploaded_file, verbose=True), (
+            f"Contents mismatch for file {uploaded_file.path.name}"
+        )
 
         # assert downloaded path is a child of the download_dir
         assert download_path.is_relative_to(download_dir), (


### PR DESCRIPTION
The names of file entries were not being set correctly when these were uploaded as a sibling of another file (i.e. when file contents are identical to another file owned by that user).

This PR fixes that and adds an integration test to cover this use case.

Also:

+ On the Gateway, reviewed severity of some logging entries.
+ The SDK now sets `local_path` attribute for all file upload modes.
