### PR TITLE
SDK: usability improvements to the capture API

### DIFF
--- a/sdk/docs/changelog.md
+++ b/sdk/docs/changelog.md
@@ -1,5 +1,19 @@
 # SpectrumX SDK Changelog
 
+## `0.1.8` - 2025-03-??
+
++ Features and improvements:
+    + [#78](https://github.com/spectrumx/sds-code/pull/78) The `capture_type` argument of `sds_client.captures.listing()` is now optional.
+    + [#78](https://github.com/spectrumx/sds-code/pull/78) The method `sds_client.captures.read()` is now available for reading a single capture, complementing the existing `sds_client.captures.listing()` method.
+    + [#78](https://github.com/spectrumx/sds-code/pull/78) When retrieving a single capture with `capture = read(<uuid>)`, the list of files associated to it is available in `capture.files`.
+        + Note these are `CaptureFile` instances, which hold a subset of the information in an SDS' `File` instance. To get all metadata on a file, use `sds_client.get_file(<uuid>)`.
++ Fixes:
+    + [#77](https://github.com/spectrumx/sds-code/pull/77) Fixed incorrect file name being set when the file contents are already in SDS.
+    + [#77](https://github.com/spectrumx/sds-code/pull/77) `local_path` is now set for uploaded files across all three upload modes.
+    + [#71](https://github.com/spectrumx/sds-code/pull/71) File permissions are now included in file uploads; redesigned handling of permission flags.
++ Housekeeping:
+    + [#76](https://github.com/spectrumx/sds-code/pull/76) Fixed documentation typos; Updated and expanded note on concurrent access in the usage guide.
+
 ## `0.1.7` - 2025-03-07
 
 + Features:

--- a/sdk/src/spectrumx/api/captures.py
+++ b/sdk/src/spectrumx/api/captures.py
@@ -78,7 +78,7 @@ class CaptureAPI:
         log.debug(f"Capture created with UUID {capture.uuid}")
         return capture
 
-    def listing(self, *, capture_type: CaptureType) -> list[Capture]:
+    def listing(self, *, capture_type: CaptureType | None = None) -> list[Capture]:
         """Lists all captures in SDS under the current user."""
         log.debug(f"Listing captures of type {capture_type}")
         captures_raw = self.gateway.list_captures(capture_type=capture_type)

--- a/sdk/src/spectrumx/api/captures.py
+++ b/sdk/src/spectrumx/api/captures.py
@@ -66,6 +66,7 @@ class CaptureAPI:
                 scan_group=uuid.UUID(scan_group) if scan_group else None,
                 top_level_dir=top_level_dir,
                 uuid=uuid4(),
+                files=[],
             )
         capture_raw = self.gateway.create_capture(
             capture_type=capture_type,

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -443,6 +443,28 @@ class GatewayClient:
         network.success_or_raise(response=response, ContextException=FileError)
         return response.content
 
+    def read_capture(
+        self,
+        *,
+        capture_uuid: uuid.UUID,
+        verbose: bool = False,
+    ) -> bytes:
+        """Reads a capture from the SDS API.
+
+        Args:
+            capture_uuid: The UUID of the capture to read.
+        Returns:
+            The response content from SDS Gateway.
+        """
+        response = self._request(
+            method=HTTPMethods.GET,
+            endpoint=Endpoints.CAPTURES,
+            asset_id=capture_uuid.hex,
+            verbose=verbose,
+        )
+        network.success_or_raise(response, ContextException=FileError)
+        return response.content
+
     def list_captures(
         self,
         *,

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -446,7 +446,7 @@ class GatewayClient:
     def list_captures(
         self,
         *,
-        capture_type: CaptureType,
+        capture_type: CaptureType | None = None,
         verbose: bool = False,
     ) -> bytes:
         """Lists captures on the SDS API.

--- a/sdk/src/spectrumx/models/captures.py
+++ b/sdk/src/spectrumx/models/captures.py
@@ -37,9 +37,22 @@ _d_index_name = "The name of the SDS index associated with the capture"
 _d_origin = "The origin of the capture"
 _d_top_level_dir = "The top-level directory for the capture files"
 _d_uuid = "The unique identifier for the capture"
+_d_capture_files = "Files associated to this capture"
 
 _d_channel = "The channel associated with the capture. Only for RadioHound type."
 _d_scan_group = "The scan group associated with the capture. Only for Digital-RF type."
+
+
+class CaptureFile(BaseModel):
+    uuid: Annotated[
+        UUID4, Field(description="The unique identifier for the capture file")
+    ]
+    name: Annotated[
+        str, Field(max_length=255, description="The name of the capture file")
+    ]
+    directory: Annotated[
+        Path, Field(description="The directory where the capture file is stored")
+    ]
 
 
 class Capture(BaseModel):
@@ -51,6 +64,7 @@ class Capture(BaseModel):
     origin: Annotated[CaptureOrigin, Field(description=_d_origin)]
     top_level_dir: Annotated[Path, Field(description=_d_top_level_dir)]
     uuid: Annotated[UUID4, Field(description=_d_uuid)]
+    files: Annotated[list[CaptureFile], Field(description=_d_capture_files)]
 
     # optional fields
     channel: Annotated[
@@ -59,7 +73,20 @@ class Capture(BaseModel):
     scan_group: Annotated[UUID4 | None, Field(description=_d_scan_group, default=None)]
 
     def __str__(self) -> str:
-        return f"<{self.__repr_name__} {self.uuid}>"
+        """Get the string representation of the capture."""
+        return (
+            f"Capture(uuid={self.uuid}, "
+            f"type={self.capture_type}, "
+            f"files={len(self.files)})"
+        )
+
+    @property
+    def __repr_name__(self) -> str:
+        """Get the name of the capture for display."""
+        return self.capture_type.value
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} {self.uuid} files={len(self.files)}>"
 
 
 __all__ = [

--- a/sdk/tests/integration/conftest.py
+++ b/sdk/tests/integration/conftest.py
@@ -113,6 +113,16 @@ class PassthruEndpoints:
         ]
 
     @staticmethod
+    def capture_reading() -> list[Pattern[str]]:
+        """Passthrough for file content download."""
+        return [  # file content download
+            re.compile(
+                rf"{hostname_and_port}{API_PATH}{API_TARGET_VERSION}{Endpoints.CAPTURES}/{uuid_v4_regex}/"
+            )
+            for hostname_and_port in passthru_hostnames
+        ]
+
+    @staticmethod
     def capture_creation() -> list[str]:
         """Passthrough for capture creation."""
         return [
@@ -122,7 +132,7 @@ class PassthruEndpoints:
 
     @classmethod
     def capture_listing(cls) -> list[str]:
-        """Passthrough for capture listing and reading."""
+        """Passthrough for capture creation and listing."""
         return cls.capture_creation()
 
     @staticmethod

--- a/sdk/tests/integration/test_captures.py
+++ b/sdk/tests/integration/test_captures.py
@@ -404,6 +404,8 @@ def test_capture_reading_drf(integration_client: Client) -> None:
     # ASSERT
 
     # basic capture information
+    log.error(f"{read_capture!s}")
+    assert read_capture.files, "Expected a list of files associated to this capture"
     assert read_capture.uuid == capture.uuid, "Capture UUID should match"
     assert read_capture.capture_type == CaptureType.DigitalRF
     assert read_capture.channel == drf_channel


### PR DESCRIPTION
+ Making `capture_type` optional for listing them.
+ Adding integration tests for listing RadioHound captures and any capture.
+ Added individual capture read and test.
+ A capture's file list is now part of the Capture dataclass and it's deserialized.
