### PR TITLE
Capture creation constraints

### DIFF
--- a/gateway/config/settings/base.py
+++ b/gateway/config/settings/base.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import environ
 
+from config.settings.logs import ColoredFormatter
+
 env = environ.Env()
 
 BASE_DIR: Path = Path(__file__).resolve(strict=True).parent.parent.parent
@@ -303,15 +305,18 @@ LOGGING: dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "verbose": {
-            "format": "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s",
+        # "verbose": {
+        #     "format": "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s",
+        # },
+        "colored": {
+            "()": ColoredFormatter,
         },
     },
     "handlers": {
         "console": {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
-            "formatter": "verbose",
+            "formatter": "colored",
         },
     },
     "root": {"level": "DEBUG", "handlers": ["console"]},

--- a/gateway/sds_gateway/api_methods/apps.py
+++ b/gateway/sds_gateway/api_methods/apps.py
@@ -17,5 +17,11 @@ class ApiMethodsConfig(AppConfig):
 def silence_unwanted_logs() -> None:
     """Usually for modules that are too verbose."""
     log.info("Silencing unwanted logs.")
-    logging.getLogger("botocore").setLevel(logging.ERROR)
-    logging.getLogger("boto3").setLevel(logging.ERROR)
+    log_map: dict[int, list[str]] = {
+        logging.ERROR: ["boto3", "botocore"],
+        logging.WARNING: ["opensearch", "urllib3"],
+    }
+    for log_level, loggers in log_map.items():
+        for logger in loggers:
+            logging.getLogger(logger).setLevel(log_level)
+            log.debug(f"Silencing {logger} at level {log_level}.")

--- a/gateway/sds_gateway/api_methods/apps.py
+++ b/gateway/sds_gateway/api_methods/apps.py
@@ -18,8 +18,15 @@ def silence_unwanted_logs() -> None:
     """Usually for modules that are too verbose."""
     log.info("Silencing unwanted logs.")
     log_map: dict[int, list[str]] = {
-        logging.ERROR: ["boto3", "botocore"],
-        logging.WARNING: ["opensearch", "urllib3"],
+        logging.ERROR: [
+            "boto3",
+            "botocore",
+        ],
+        logging.WARNING: [
+            "opensearch",
+            "s3transfer",
+            "urllib3",
+        ],
     }
     for log_level, loggers in log_map.items():
         for logger in loggers:

--- a/gateway/sds_gateway/api_methods/helpers/search_captures.py
+++ b/gateway/sds_gateway/api_methods/helpers/search_captures.py
@@ -202,10 +202,10 @@ def search_captures(
         owner:              user who owns the captures
         capture_type:       type of capture to filter by
         metadata_filters:   dict of metadata field names and their filter values
+    Raises:
+        ValueError:         when the index was not found
     Returns:
         QuerySet of Capture objects matching the criteria
-    Raises:
-        ValueError: If the capture type is invalid
     """
 
     capture_queryset: QuerySet[Capture] = get_capture_queryset(

--- a/gateway/sds_gateway/api_methods/helpers/search_captures.py
+++ b/gateway/sds_gateway/api_methods/helpers/search_captures.py
@@ -1,10 +1,12 @@
 """Helper functions for searching captures with metadata filtering."""
 
-import logging
+from collections.abc import Mapping
 from typing import Any
 
 from django.db.models import QuerySet
+from loguru import logger as log
 from opensearchpy import exceptions as os_exceptions
+from rich.pretty import pretty_repr
 
 from sds_gateway.api_methods.models import Capture
 from sds_gateway.api_methods.models import CaptureType
@@ -14,8 +16,6 @@ from sds_gateway.api_methods.utils.metadata_schemas import (
 )
 from sds_gateway.api_methods.utils.opensearch_client import get_opensearch_client
 from sds_gateway.users.models import User
-
-logger = logging.getLogger(__name__)
 
 RangeValue = dict[str, int | float]
 UNKNOWN_CAPTURE_TYPE = "Unknown capture type"
@@ -35,7 +35,6 @@ def handle_nested_query(
         query_type: Type of query (e.g. 'match', 'term')
         value: Value to match against
         levels_nested: Number of nested levels to traverse
-
     Returns:
         Nested query dictionary for OpenSearch
     """
@@ -52,17 +51,17 @@ def handle_nested_query(
         "nested": {
             "path": current_path,
             "query": handle_nested_query(
-                ".".join(path_parts[1:]),
-                query_type,
-                value,
-                levels_nested - 1,
-                current_path,
+                field_path=".".join(path_parts[1:]),
+                query_type=query_type,
+                value=value,
+                levels_nested=levels_nested - 1,
+                last_path=current_path,
             ),
-        }
+        },
     }
 
 
-def build_metadata_query(
+def _build_os_metadata_query(
     capture_type: CaptureType | None = None,
     metadata_filters: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
@@ -71,35 +70,24 @@ def build_metadata_query(
     Args:
         capture_type: Type of capture (e.g. 'drf')
         metadata_filters: list of dicts with 'field', 'type', and 'value' keys
-
     Returns:
         List of OpenSearch query clauses for the metadata fields
     """
 
-    if not capture_type:
-        # Merge all capture type properties into a single flat dictionary
-        index_mapping = {}
-        for ct in CaptureType:
-            if ct != CaptureType.SigMF:
-                index_mapping.update(md_props_by_type[ct])
-    else:
-        index_mapping = md_props_by_type.get(capture_type, {})
+    metadata_queries: list[dict[str, Any]] = []
+    if metadata_filters is None:
+        log.debug("No metadata filters provided to build the OpenSearch query.")
+        return metadata_queries
 
-    # flatten the index mapping to list of fields
-    index_fields = base_index_fields.copy()  # Start with a copy of base fields
-    for field, field_type in index_mapping.items():
-        if isinstance(field_type, dict) and field_type.get("type") == "nested":
-            for nested_field in field_type.get("properties", {}):
-                index_fields.append(f"capture_props.{field}.{nested_field}")
-        else:
-            index_fields.append(f"capture_props.{field}")
+    index_fields = _flatten_index_mapping(
+        index_mapping=_get_index_mapping(capture_type=capture_type),
+        index_fields=base_index_fields.copy(),
+    )
 
-    # Build metadata query
-    metadata_queries = []
     for query in metadata_filters:
-        field_path = query["field_path"]
-        query_type = query["query_type"]
-        filter_value = query["filter_value"]
+        field_path: str = query["field_path"]
+        query_type: str = query["query_type"]
+        filter_value: Any = query["filter_value"]
 
         # warn if the field is not in the index mapping
         # but continue to build the query
@@ -108,65 +96,179 @@ def build_metadata_query(
                 f"Field '{field_path}' does not match an indexed field."
                 "The filter may not be applied to the query accurately."
             )
-            logger.warning(msg)
+            log.warning(msg)
 
-        if field_path.count(".") > 0:
-            levels_nested = len(field_path.split(".")) - 1
+        if levels_nested := field_path.count(".") > 0:
             metadata_queries.append(
                 handle_nested_query(
-                    field_path,
-                    query_type,
-                    filter_value,
-                    levels_nested,
-                )
+                    field_path=field_path,
+                    query_type=query_type,
+                    value=filter_value,
+                    levels_nested=levels_nested,
+                ),
             )
         else:
             metadata_queries.append({query_type: {field_path: filter_value}})
 
+    log.debug(
+        f"Built {len(metadata_queries)} OpenSearch metadata "
+        f"queries: {metadata_queries}",
+    )
     return metadata_queries
 
 
+def _flatten_index_mapping(
+    index_mapping: Mapping[str, Any],
+    index_fields: list[str],
+    prefix: str = "capture_props",
+    separator: str = ".",
+) -> list[str]:
+    """Flatten the index mapping to a list of fields.
+    Args:
+        index_mapping: The index mapping to flatten.
+        index_fields: The list of fields to flatten.
+    Returns:
+        A list of flattened fields.
+    """
+    for field, field_type in index_mapping.items():
+        if isinstance(field_type, dict) and field_type.get("type") == "nested":
+            index_fields.extend(
+                [
+                    f"{prefix}{separator}{field}{separator}{nested_field}"
+                    for nested_field in field_type.get("properties", {})
+                ],
+            )
+        else:
+            index_fields.append(f"{prefix}{separator}{field}")
+    return index_fields
+
+
+def _get_index_mapping(capture_type: CaptureType | None) -> dict[str, dict[str, Any]]:
+    """Retrieves the OpenSearch index mapping for a given capture type or all types.
+
+    Args:
+        capture_type: The capture type for which the index mapping is requested.
+                      If None, the function merges all capture type properties.
+    Raises:
+        ValueError: If the capture type is not None and is not recognized.
+    Returns:
+        A dict where the keys are property names and the values are dicts with
+        metadata for the specified capture type or all capture types combined.
+    """
+    implemented_capture_types = set(md_props_by_type.keys())
+    assert implemented_capture_types, (
+        "No capture types are implemented. Please check the metadata properties."
+    )
+
+    if capture_type is not None:
+        if capture_type not in implemented_capture_types:
+            msg = f"{UNKNOWN_CAPTURE_TYPE}: {capture_type}"
+            raise ValueError(msg)
+        index_mapping = md_props_by_type.get(capture_type, {})
+    else:
+        # merge all capture type properties into a single flat dictionary
+        index_mapping = {}
+        for ct in implemented_capture_types:
+            index_mapping.update(md_props_by_type[ct])
+    return index_mapping
+
+
+def get_capture_queryset(
+    owner: User,
+    capture_type: CaptureType | None,
+) -> QuerySet[Capture]:
+    """Get the capture queryset based on the capture type."""
+    # start with base queryset filtered by user and not deleted
+    capture_queryset = Capture.objects.filter(owner=owner, is_deleted=False)
+
+    # filter by capture type if provided
+    if capture_type:
+        # verify capture type exists before filtering
+        if not md_props_by_type.get(capture_type):
+            raise ValueError(UNKNOWN_CAPTURE_TYPE)
+        capture_queryset = capture_queryset.filter(capture_type=capture_type)
+
+    return capture_queryset
+
+
 def search_captures(
-    user: User,
+    owner: User,
     capture_type: CaptureType | None = None,
     metadata_filters: list[dict[str, Any]] | None = None,
 ) -> QuerySet[Capture]:
     """Search for captures with optional metadata filtering.
 
     Args:
-        user: User to filter captures by ownership (required)
-        capture_type: Optional type of capture to filter by (e.g. 'drf')
-        metadata_filters: Optional dict of metadata field names and their filter values
-
+        owner:              user who owns the captures
+        capture_type:       type of capture to filter by
+        metadata_filters:   dict of metadata field names and their filter values
     Returns:
         QuerySet of Capture objects matching the criteria
-
     Raises:
         ValueError: If the capture type is invalid
     """
 
-    # Start with base queryset filtered by user
-    # Start with base queryset filtered by user and not deleted
-    captures = Capture.objects.filter(owner=user, is_deleted=False)
-
-    # Filter by capture type if provided
-    if capture_type:
-        # Verify capture type exists before filtering
-        if not md_props_by_type.get(capture_type):
-            raise ValueError(UNKNOWN_CAPTURE_TYPE)
-        captures = captures.filter(capture_type=capture_type)
-
-    # If no metadata filters, return all matching captures
-    if not metadata_filters:
-        return captures
-
-    # Build metadata query
-    metadata_queries = build_metadata_query(capture_type, metadata_filters)
+    capture_queryset: QuerySet[Capture] = get_capture_queryset(
+        capture_type=capture_type,
+        owner=owner,
+    )
+    metadata_queries: list[dict[str, Any]] = _build_os_metadata_query(
+        capture_type=capture_type,
+        metadata_filters=metadata_filters,
+    )
     if not metadata_queries:
-        return captures
+        log.debug("No metadata queries provided. Returning all captures.")
+        return capture_queryset
+    os_query = _build_os_query_for_captures(
+        capture_type=capture_type,
+        metadata_queries=metadata_queries,
+    )
 
-    # Build the query
-    must_clauses = []
+    client = get_opensearch_client()
+    index_name: str = (
+        "captures-*" if capture_type is None else f"captures-{capture_type}"
+    )
+
+    try:
+        response = client.search(
+            index=index_name,
+            body=os_query,
+        )
+    except os_exceptions.NotFoundError as err:
+        msg = f"Index '{index_name}' not found"
+        log.exception(msg)
+        raise ValueError(msg) from err
+    except os_exceptions.ConnectionError as err:
+        msg = f"Failed to connect to OpenSearch: {err}"
+        log.exception(msg)
+        raise
+    except os_exceptions.RequestError as err:
+        msg = f"OpenSearch request error: {err}"
+        log.exception(msg)
+        raise
+    except os_exceptions.OpenSearchException as err:
+        msg = f"OpenSearch generic error: {err}"
+        log.exception(msg)
+        raise
+    else:
+        matching_uuids = [hit["_id"] for hit in response["hits"]["hits"]]
+        return capture_queryset.filter(uuid__in=matching_uuids).order_by("-updated_at")
+
+
+def _build_os_query_for_captures(
+    capture_type: CaptureType | None,
+    metadata_queries: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the OpenSearch query for searching captures.
+
+    Args:
+        capture_type:       The type of capture to filter by, or None for all types.
+        metadata_queries:   A list of metadata query clauses to include in the query.
+
+    Returns:
+        A dictionary representing the OpenSearch query.
+    """
+    must_clauses: list[dict[str, dict[str, Any]]] = []
     if capture_type:
         must_clauses.append({"term": {"capture_type": capture_type}})
     must_clauses.extend(metadata_queries)
@@ -178,41 +280,6 @@ def search_captures(
             },
         },
     }
-
-    # Search OpenSearch
-    client = get_opensearch_client()
-
-    index_name = "captures-*" if capture_type is None else f"captures-{capture_type}"
-
-    try:
-        response = client.search(
-            index=index_name,
-            body=query,
-        )
-        # Get UUIDs of matching documents
-        matching_uuids = [hit["_id"] for hit in response["hits"]["hits"]]
-        # Filter captures by matching UUIDs
-        return captures.filter(uuid__in=matching_uuids)
-    except os_exceptions.NotFoundError as err:
-        # Log the error
-        msg = f"Index '{index_name}' not found"
-        logger.exception(msg)
-        raise ValueError(msg) from err
-    except os_exceptions.ConnectionError as e:
-        # Log the error
-        msg = f"Failed to connect to OpenSearch: {e}"
-        logger.exception(msg)
-        # Handle the error (e.g., retry, raise an exception, etc.)
-        raise
-    except os_exceptions.RequestError as e:
-        # Log the error
-        msg = f"OpenSearch query error: {e}"
-        logger.exception(msg)
-        # Handle the error (e.g., retry, raise an exception, etc.)
-        raise
-    except os_exceptions.OpenSearchException as e:
-        # Log the error
-        msg = f"OpenSearch error: {e}"
-        logger.exception(msg)
-        # Handle the error (e.g., retry, raise an exception, etc.)
-        raise
+    log.debug("OpenSearch query:")
+    log.debug(pretty_repr(query, indent_size=4))
+    return query

--- a/gateway/sds_gateway/api_methods/helpers/search_captures.py
+++ b/gateway/sds_gateway/api_methods/helpers/search_captures.py
@@ -98,7 +98,8 @@ def _build_os_metadata_query(
             )
             log.warning(msg)
 
-        if levels_nested := field_path.count(".") > 0:
+        levels_nested = field_path.count(".")
+        if levels_nested > 0:
             metadata_queries.append(
                 handle_nested_query(
                     field_path=field_path,

--- a/gateway/sds_gateway/api_methods/helpers/search_captures.py
+++ b/gateway/sds_gateway/api_methods/helpers/search_captures.py
@@ -188,7 +188,7 @@ def get_capture_queryset(
             raise ValueError(UNKNOWN_CAPTURE_TYPE)
         capture_queryset = capture_queryset.filter(capture_type=capture_type)
 
-    return capture_queryset
+    return capture_queryset.order_by("-updated_at")
 
 
 def search_captures(

--- a/gateway/sds_gateway/api_methods/serializers/capture_serializers.py
+++ b/gateway/sds_gateway/api_methods/serializers/capture_serializers.py
@@ -136,35 +136,6 @@ class CapturePostSerializer(serializers.ModelSerializer[Capture]):
             self._errors = {"capture_type": ["Invalid capture type."]}
             return super().is_valid(raise_exception=raise_exception)
 
-        # capture creation constraints
-
-        # check that if capture_type is DigitalRF,
-        # then channel and top_level_dir are unique
-        if capture_type == CaptureType.DigitalRF:
-            if Capture.objects.filter(
-                channel=initial_data["channel"],
-                top_level_dir=initial_data["top_level_dir"],
-                capture_type=CaptureType.DigitalRF,
-                is_deleted=False,
-                owner=self.context["request_user"],
-            ).exists():
-                self._errors = {
-                    "channel": [
-                        "This channel and top level directory are already in use.",
-                    ],
-                }
-
-        # check that if capture_type is RadioHound,
-        # then scan_group is unique
-        if capture_type == CaptureType.RadioHound:
-            if Capture.objects.filter(
-                scan_group=initial_data["scan_group"],
-                capture_type=CaptureType.RadioHound,
-                is_deleted=False,
-                owner=self.context["request_user"],
-            ).exists():
-                self._errors = {"scan_group": ["This scan group is already in use."]}
-
         # check that the required fields are in the initial data
         for field in self.get_required_fields(capture_type):
             if field not in initial_data:

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -352,12 +352,9 @@ class CaptureTestCases(APITestCase):
                 f"Unexpected status code: {response_raw.status_code}"
             )
             response = response_raw.json()
-            assert "scan_group" in response, (
-                f"'scan_group' key missing in response: {response}"
+            assert "scan group is already in use" in response["detail"], (
+                f"Unexpected error message: {response['detail']}"
             )
-            assert response["scan_group"] == [
-                "This scan group is already in use.",
-            ], f"Unexpected error message: {response['scan_group']}"
 
     def test_update_capture_404(self) -> None:
         """Test updating a non-existent capture returns 404."""

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -421,9 +421,17 @@ class CaptureTestCases(APITestCase):
             deleted_at=datetime.datetime.now(datetime.UTC),
         )
 
-        response = self.client.get(self.list_url)
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == [], "Expected no captures"
+        response_raw = self.client.get(self.list_url)
+        assert response_raw.status_code == status.HTTP_200_OK
+        response = response_raw.json()
+        assert "count" in response, "Expected 'count' in response"
+        assert response["count"] == 0, "Expected count to be 0"
+        assert "results" in response, "Expected 'results' in response"
+        assert response["results"] == [], "Expected results to be empty list"
+        assert "next" in response, "Expected 'next' in response"
+        assert response["next"] is None, "Expected 'next' to be None"
+        assert "previous" in response, "Expected 'previous' in response"
+        assert response["previous"] is None, "Expected 'previous' to be None"
 
     def test_list_captures_no_metadata_200(self) -> None:
         """Listing captures when metadata is missing should not fail."""

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -410,18 +410,27 @@ class CaptureTestCases(APITestCase):
 
     def test_list_captures_by_type_200(self) -> None:
         """Test filtering captures by type returns correct metadata."""
-        response = self.client.get(
+        response_raw = self.client.get(
             f"{self.list_url}?capture_type={CaptureType.DigitalRF}",
         )
-        assert response.status_code == status.HTTP_200_OK
+        assert response_raw.status_code == status.HTTP_200_OK
 
-        data = response.json()
-        assert len(data) == 1
-        assert data[0]["capture_type"] == CaptureType.DigitalRF
+        response = response_raw.json()
+        assert "count" in response, "Expected 'count' in response"
+        assert response["count"] == 1, "Expected count to be 1"
+        assert "results" in response, "Expected 'results' in response"
+        assert len(response["results"]) == 1, "Expected results to be 1"
+        assert "next" in response, "Expected 'next' in response"
+        assert "previous" in response, "Expected 'previous' in response"
 
-        # Verify metadata is correctly retrieved for filtered list
-        assert data[0]["capture_props"] == self.drf_metadata
-        assert data[0]["channel"] == "ch0"
+        results = response["results"]
+
+        assert all(
+            capture["capture_type"] == CaptureType.DigitalRF for capture in results
+        ), "Expected all captures to be of type DigitalRF"
+
+        assert results[0]["capture_props"] == self.drf_metadata
+        assert results[0]["channel"] == "ch0"
 
     def test_list_captures_by_type_empty_list_200(self) -> None:
         """Test filtering captures by type that doesn't exist returns empty list."""

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -448,11 +448,15 @@ class CaptureTestCases(APITestCase):
         assert results[0]["capture_props"] == self.drf_metadata
         assert results[0]["channel"] == "ch0"
 
-    def test_list_captures_by_type_empty_list_200(self) -> None:
-        """Test filtering captures by type that doesn't exist returns empty list."""
-        response = self.client.get(f"{self.list_url}?capture_type=fake_type")
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == []
+    def test_list_captures_by_invalid_type_400(self) -> None:
+        """Test filtering captures by an invalid type returns 400."""
+        fake_type: str = "fake_type"
+        response_raw = self.client.get(f"{self.list_url}?capture_type={fake_type}")
+        assert response_raw.status_code == status.HTTP_400_BAD_REQUEST
+        response = response_raw.json()
+        assert f"{fake_type}" in response["detail"].lower(), (
+            f"Expected '{fake_type}' in error message, got {response['detail']}"
+        )
 
     def test_list_captures_empty_list_200(self) -> None:
         """Test list captures returns 200 when no captures exist."""

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -86,23 +86,23 @@ class CaptureTestCases(APITestCase):
 
         # Define test metadata
         self.drf_metadata = {
-            "center_freq": 2000000000,
-            "bandwidth": 20000000,
+            "center_freq": 2_000_000_000,
+            "bandwidth": 20_000_000,
             "gain": 20.5,
         }
 
         self.rh_metadata = {
             "altitude": 2.0,
             "batch": 0,
-            "center_frequency": 2000000000.0,
+            "center_frequency": 2_000_000_000.0,
             "scan_group": str(self.scan_group),
             "custom_fields": {
                 "requested": {
-                    "fmax": 2010000000,
-                    "fmin": 1990000000,
+                    "fmax": 2_010_000_000,
+                    "fmin": 1_990_000_000,
                     "gain": 1,
                     "samples": 1024,
-                    "span": 20000000,
+                    "span": 20_000_000,
                 },
             },
             "gain": 1.0,
@@ -116,13 +116,13 @@ class CaptureTestCases(APITestCase):
             "metadata": {
                 "archive_result": True,
                 "data_type": "periodogram",
-                "fmax": 2012000000,
-                "fmin": 1988000000,
+                "fmax": 2_012_000_000,
+                "fmin": 1_988_000_000,
                 "gps_lock": False,
                 "nfft": 1024,
                 "scan_time": 0.07766938209533691,
             },
-            "sample_rate": 24000000,
+            "sample_rate": 24_000_000,
             "short_name": "WI-Lab V3.4-025 #6",
             "software_version": "v0.10b30",
             "timestamp": "2025-01-10T15:48:07.100486Z",
@@ -308,7 +308,7 @@ class CaptureTestCases(APITestCase):
             )
             assert response.status_code == status.HTTP_400_BAD_REQUEST
             assert response.json()["channel"] == [
-                "This channel and top level directory are already in use."
+                "This channel and top level directory are already in use.",
             ]
 
     def test_create_rh_capture_already_exists(self) -> None:
@@ -338,7 +338,7 @@ class CaptureTestCases(APITestCase):
             )
             assert response.status_code == status.HTTP_400_BAD_REQUEST
             assert response.json()["scan_group"] == [
-                "This scan group is already in use."
+                "This scan group is already in use.",
             ]
 
     def test_update_capture_404(self) -> None:
@@ -352,7 +352,7 @@ class CaptureTestCases(APITestCase):
         """Test updating a capture returns 200 with new metadata."""
         # update the metadata dict and insert into the capture update payload
         new_metadata = self.drf_metadata.copy()
-        new_metadata["center_freq"] = 1500000000
+        new_metadata["center_freq"] = 1_500_000_000
         new_metadata["gain"] = 10.5
 
         with patch(
@@ -448,7 +448,7 @@ class CaptureTestCases(APITestCase):
         Test listing captures with metadata filters returns captures
         with matching metadata, without type distinction.
         """
-        center_freq = 2000000000
+        center_freq = 2_000_000_000
         metadata_filters = [
             {
                 "field_path": "capture_props.center_freq",
@@ -461,7 +461,9 @@ class CaptureTestCases(APITestCase):
         )
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert data["count"] == 1, "Expected to find the DRF capture"
+        assert data["count"] == 1, (
+            f"Expected to find the DRF capture, got count: {data['count']}"
+        )
         returned_center_freq = data["results"][0]["capture_props"]["center_freq"]
         assert returned_center_freq == center_freq, (
             "Center frequency should be equal to the filter value: "
@@ -473,7 +475,7 @@ class CaptureTestCases(APITestCase):
         Test listing captures with metadata filters returns
         the rh capture with matching metadata.
         """
-        center_freq = 2000000000
+        center_freq = 2_000_000_000
         metadata_filters = [
             {
                 "field_path": "capture_props.metadata.fmax",

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -274,21 +274,29 @@ class CaptureTestCases(APITestCase):
                 ),
             ),
         ):
-            response = self.client.post(
+            response_raw = self.client.post(
                 self.list_url,
                 data={
                     "capture_type": CaptureType.RadioHound,
                     "scan_group": str(unique_scan_group),
-                    "index_name": "captures-rh",
                     "top_level_dir": "test-dir-rh",
                 },
             )
-            assert response.status_code == status.HTTP_201_CREATED
-            assert response.json()["capture_props"] == self.rh_metadata
-            assert response.json()["capture_type"] == CaptureType.RadioHound
-            assert (
-                response.json()["top_level_dir"]
-                == "/files/testuser@example.com/test-dir"
+            assert response_raw.status_code == status.HTTP_201_CREATED, (
+                f"Unexpected status code: {response_raw.status_code}"
+            )
+            response = response_raw.json()
+            assert response["scan_group"] == str(
+                unique_scan_group,
+            ), f"Unexpected scan group: {response['scan_group']}"
+            assert response["capture_props"] == self.rh_metadata, (
+                f"Unexpected metadata: {response['capture_props']}"
+            )
+            assert response["capture_type"] == CaptureType.RadioHound, (
+                f"Unexpected capture type: {response['capture_type']}"
+            )
+            assert response["top_level_dir"] == "test-dir-rh", (
+                f"Unexpected top level dir: {response['top_level_dir']}"
             )
 
     def test_create_drf_capture_already_exists(self) -> None:
@@ -303,7 +311,6 @@ class CaptureTestCases(APITestCase):
                     "capture_type": CaptureType.DigitalRF,
                     "channel": self.channel,
                     "top_level_dir": "test-dir-drf",
-                    "index_name": "captures-drf",
                 },
             )
             assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -305,7 +305,7 @@ class CaptureTestCases(APITestCase):
             "sds_gateway.api_methods.views.capture_endpoints.validate_metadata_by_channel",
             return_value=self.drf_metadata,
         ):
-            response = self.client.post(
+            response_raw = self.client.post(
                 self.list_url,
                 data={
                     "capture_type": CaptureType.DigitalRF,
@@ -313,10 +313,12 @@ class CaptureTestCases(APITestCase):
                     "top_level_dir": "test-dir-drf",
                 },
             )
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
-            assert response.json()["channel"] == [
-                "This channel and top level directory are already in use.",
-            ]
+            assert response_raw.status_code == status.HTTP_400_BAD_REQUEST
+            response = response_raw.json()
+            assert (
+                "channel and top level directory are already in use"
+                in response["detail"]
+            ), f"Unexpected error message: {response['detail']}"
 
     def test_create_rh_capture_scan_group_conflict(self) -> None:
         """Test creating rh capture with existing scan group returns error."""

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -386,9 +386,9 @@ class CaptureViewSet(viewsets.ViewSet):
     def list(self, request: Request) -> Response:
         """List captures with optional metadata filtering."""
         capture_type_raw = request.GET.get("capture_type", None)
-        capture_type = CaptureType(capture_type_raw) if capture_type_raw else None
 
         try:
+            capture_type = CaptureType(capture_type_raw) if capture_type_raw else None
             metadata_filters = self._validate_metadata_filters(
                 request.GET.get("metadata_filters"),
             )


### PR DESCRIPTION
+ Capture creation constraints:
	+ Moved constraints logic from validation to a separate step during creation: because the validation code doesn't have the context about which operation is being performed (e.g. creation or update).
+ Updated capture tests:
	+ Updated the expectations from several capture tests, which are now passing.
	+ The newer tests `test_list_captures_with_metadata_filters_*` don't are not passing yet: I think it'll make sense to work on these with PR #80 instead.
+ Logging work:
    + Colored default loggers, now with module and function names, and line numbers to help finding their source.
    + Increased logging level for more third-party packages, that were just adding noise to the output making relevant information harder to find.
