### PR TITLE
SDK capture deletions

### DIFF
--- a/gateway/makefile
+++ b/gateway/makefile
@@ -42,5 +42,9 @@ restart:
 
 test:
 	@echo "Running tests"
-	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) pytest
-	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) python manage.py test --force-color
+
+	# we currently don't have tests for pytest, so we're ignoring its return code with `|| true`
+	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) pytest || true
+
+	# the real tests are using Django's test runner
+	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) python manage.py test --force-color --verbosity 0

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -662,10 +662,13 @@ def _check_capture_creation_constraints(
                 "value should have been caught by the serializer validator.",
             )
         elif cap_qs.exists():
+            conflicting_capture = cap_qs.first()
+            assert conflicting_capture is not None, "QuerySet should not be empty here."
             _errors.update(
                 {
                     "drf_unique_channel_and_tld": "This channel and top level "
-                    "directory are already in use.",
+                    "directory are already in use by "
+                    f"another capture: {conflicting_capture.pk}",
                 },
             )
         else:
@@ -688,9 +691,12 @@ def _check_capture_creation_constraints(
                 "No scan group provided for RadioHound capture.",
             )
         elif cap_qs.exists():
+            conflicting_capture = cap_qs.first()
+            assert conflicting_capture is not None, "QuerySet should not be empty here."
             _errors.update(
                 {
-                    "rh_unique_scan_group": "This scan group is already in use.",
+                    "rh_unique_scan_group": f"This scan group is already in use by "
+                    f"another capture: {conflicting_capture.pk}",
                 },
             )
         else:

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -282,15 +282,20 @@
         # more verbose:
         # addopts = "--maxfail=2 --new-first -rf --strict-markers --cov=src --cov-report=html --show-capture=stdout -o log_cli=true --showlocals --tb=long --capture=no"
         # less verbose:
-        addopts              = "--maxfail=2 --new-first -rf --strict-markers --cov=src --cov-report=html --show-capture=stdout -o log_cli=true --tb=short"
+        addopts = "--maxfail=2 --new-first -rf --strict-markers --cov=src --cov-report=html --show-capture=stdout -o log_cli=true --tb=short"
         console_output_style = "progress"
-        log_auto_indent      = true
-        log_cli              = true
-        log_cli_level        = "WARN"
-        log_date_format      = "%Y-%m-%d %H:%M:%S"
-        markers              = ["integration: marks a test as an integration test", "linux: marks a test to run on linux", "darwin: marks a test to run on Mac OS", "win32: marks a test to run on windows"]
-        minversion           = "8.0"
-        testpaths            = ["tests"]
+        log_auto_indent = true
+        log_cli = true
+        log_cli_level = "WARN"
+        log_date_format = "%Y-%m-%d %H:%M:%S"
+        markers = [
+            "integration: marks a test as an integration test",
+            "linux: marks a test to run on linux",
+            "darwin: marks a test to run on Mac OS",
+            "win32: marks a test to run on windows",
+        ]
+        minversion = "8.0"
+        testpaths = ["tests"]
         verbosity_test_cases = 2
 
 # ====== UV

--- a/sdk/src/spectrumx/api/captures.py
+++ b/sdk/src/spectrumx/api/captures.py
@@ -153,7 +153,6 @@ class CaptureAPI:
 
     def update(
         self,
-        *,
         capture_uuid: uuid.UUID,
     ) -> None:
         """Updates a capture in SDS by re-discovering and re-indexing the files.
@@ -180,7 +179,6 @@ class CaptureAPI:
 
     def read(
         self,
-        *,
         capture_uuid: uuid.UUID,
     ) -> Capture:
         """Reads a specific capture from SDS.
@@ -201,7 +199,7 @@ class CaptureAPI:
         log.debug(f"Capture read with UUID {capture.uuid}")
         return capture
 
-    def delete(self, *, capture_uuid: uuid.UUID) -> bool:
+    def delete(self, capture_uuid: uuid.UUID) -> bool:
         """Deletes a capture from SDS by its UUID.
 
         Args:

--- a/sdk/src/spectrumx/api/captures.py
+++ b/sdk/src/spectrumx/api/captures.py
@@ -201,6 +201,26 @@ class CaptureAPI:
         log.debug(f"Capture read with UUID {capture.uuid}")
         return capture
 
+    def delete(self, *, capture_uuid: uuid.UUID) -> bool:
+        """Deletes a capture from SDS by its UUID.
+
+        Args:
+            capture_uuid:   The UUID of the capture to delete.
+        Returns:
+            True if the capture was deleted successfully, or if in dry run mode.
+        Raises:
+            CaptureError: If the capture couldn't be deleted e.g.: if it doesn't exist;
+                if it has already been deleted; if this user doesn't own it.
+        """
+        log.debug(f"Deleting capture with UUID {capture_uuid}")
+
+        if self.dry_run:
+            log.debug(f"Dry run enabled: would delete capture {capture_uuid}")
+            return True
+        self.gateway.delete_capture(capture_uuid=capture_uuid)
+        log.debug(f"Capture deleted with UUID {capture_uuid}")
+        return True
+
 
 def _extract_page_from_payload(
     capture_result_raw: bytes,

--- a/sdk/src/spectrumx/api/sds_files.py
+++ b/sdk/src/spectrumx/api/sds_files.py
@@ -149,6 +149,7 @@ def list_files(
     Returns:
         A paginator for the files in the given SDS path.
     """
+    sds_path = PurePosixPath(sds_path)
     if client.dry_run:
         log_user("Dry run enabled: files will be simulated")
     pagination: Paginator[File] = Paginator(

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -22,6 +22,7 @@ from pydantic import Field
 from spectrumx.models.captures import CaptureType
 
 from .errors import AuthError
+from .errors import CaptureError
 from .errors import FileError
 from .models.files import File
 from .models.files import FileUpload
@@ -409,10 +410,8 @@ class GatewayClient:
         Args:
             uuid: The UUID of the file to delete as a hex string.
             verbose: Whether to log the request.
-
         Returns:
             True if the file was deleted successfully.
-
         Raises:
             FileError: If the file could not be deleted.
         """
@@ -531,3 +530,22 @@ class GatewayClient:
         )
         network.success_or_raise(response, ContextException=FileError)
         return response.content
+
+    def delete_capture(self, *, capture_uuid: uuid.UUID) -> None:
+        """Deletes a capture from SDS by its UUID.
+
+        Args:
+            capture_uuid: The UUID of the capture to delete.
+        Raises:
+            GatewayError: If the deletion request fails.
+        """
+        endpoint = f"/captures/{capture_uuid}"
+        log.debug(f"Sending DELETE request to {endpoint}")
+
+        response = self._request(
+            method=HTTPMethods.DELETE,
+            endpoint=Endpoints.CAPTURES,
+            asset_id=capture_uuid.hex,
+        )
+        network.success_or_raise(response, ContextException=CaptureError)
+        log.debug(f"Capture with UUID {capture_uuid} deleted successfully")

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -539,7 +539,7 @@ class GatewayClient:
         Raises:
             GatewayError: If the deletion request fails.
         """
-        endpoint = f"/captures/{capture_uuid}"
+        endpoint = f"{Endpoints.CAPTURES}/{capture_uuid.hex}"
         log.debug(f"Sending DELETE request to {endpoint}")
 
         response = self._request(

--- a/sdk/src/spectrumx/gateway.py
+++ b/sdk/src/spectrumx/gateway.py
@@ -464,7 +464,7 @@ class GatewayClient:
             data=payload,
             verbose=verbose,
         )
-        network.success_or_raise(response=response, ContextException=FileError)
+        network.success_or_raise(response=response, ContextException=CaptureError)
         return response.content
 
     def read_capture(
@@ -486,7 +486,7 @@ class GatewayClient:
             asset_id=capture_uuid.hex,
             verbose=verbose,
         )
-        network.success_or_raise(response, ContextException=FileError)
+        network.success_or_raise(response, ContextException=CaptureError)
         return response.content
 
     def list_captures(
@@ -506,7 +506,7 @@ class GatewayClient:
             verbose=verbose,
             params={"capture_type": capture_type},
         )
-        network.success_or_raise(response, ContextException=FileError)
+        network.success_or_raise(response, ContextException=CaptureError)
         return response.content
 
     def update_capture(
@@ -528,7 +528,7 @@ class GatewayClient:
             asset_id=capture_uuid.hex,
             verbose=verbose,
         )
-        network.success_or_raise(response, ContextException=FileError)
+        network.success_or_raise(response, ContextException=CaptureError)
         return response.content
 
     def delete_capture(self, *, capture_uuid: uuid.UUID) -> None:

--- a/sdk/src/spectrumx/ops/pagination.py
+++ b/sdk/src/spectrumx/ops/pagination.py
@@ -41,17 +41,17 @@ class Paginator(Generic[T]):
     ## Usage example
 
     ```
-    paginator = Paginator[File](
+    file_paginator = Paginator[File](
         Entry=File,
         gateway=gateway,
         sds_path="/path/to/files",
         dry_run=False,
         verbose=True,
     )
-    print(f"Total files matched: {len(paginator)}")
+    print(f"Total files matched: {len(file_paginator)}")
     # len() will fetch the first page
 
-    for my_file in paginator:
+    for my_file in file_paginator:
         print(f"Processing file: {my_file.name}")
         process_file(my_file)
         # new pages are fetched automatically
@@ -77,14 +77,14 @@ class Paginator(Generic[T]):
         """Initializes the paginator with the required parameters.
 
         Args:
-            Entry:      The model class to use when parsing the entries.
-            gateway:    The gateway client to use for fetching pages.
-            sds_path:   The SDS path to paginate through.
-            dry_run:    If True, will generate synthetic pages instead of fetching.
-            page_size:  The number of entries to fetch per page.
-            start_page: The page number to start fetching from.
-            total_matches: The total number of entries to expect.
-            verbose:    If True, will log more information about the pagination.
+            Entry:          The SDSModel subclass to use when parsing the entries.
+            gateway:        The gateway client to use for fetching pages.
+            sds_path:       The SDS path to paginate through.
+            dry_run:        If True, will generate synthetic pages instead of fetching.
+            page_size:      The number of entries to fetch per page.
+            start_page:     The page number to start fetching from.
+            total_matches:  The total number of entries across all pages.
+            verbose:        If True, will log more information about the pagination.
         """
 
         if page_size <= 0:  # pragma: no cover
@@ -98,8 +98,8 @@ class Paginator(Generic[T]):
         ):  # pragma: no cover
             msg = "Total matches must be an integer."
             raise ValueError(msg)
-        if not isinstance(sds_path, (PurePosixPath, str)):  # pragma: no cover
-            msg = "SDS path must be a PurePosixPath or str."
+        if not isinstance(sds_path, (PurePosixPath, Path, str)):  # pragma: no cover
+            msg = "SDS path must be a PurePosixPath, Path, or str."
             raise TypeError(msg)
         if not isinstance(gateway, GatewayClient):  # pragma: no cover
             msg = "Gateway client must be provided."

--- a/sdk/tests/e2e_examples/check_build_acceptance.py
+++ b/sdk/tests/e2e_examples/check_build_acceptance.py
@@ -226,6 +226,13 @@ def check_capture_usage() -> None:
     for capture in my_rh_captures:
         print(f"Capture {capture.uuid}: {capture.capture_props}")
 
+    is_deleted = sds.captures.delete(
+        new_capture.uuid  # retain as positional arg
+    )
+    print(f"Deleted capture {new_capture.uuid}: {is_deleted}")
+    # double deleting a capture raises a CaptureError, unless in dry_run mode
+    # (then the SDK can't determine whether the capture exists or not)
+
 
 @dataclass
 class CheckCaller:

--- a/sdk/tests/integration/conftest.py
+++ b/sdk/tests/integration/conftest.py
@@ -130,6 +130,16 @@ class PassthruEndpoints:
             for hostname_and_port in passthru_hostnames
         ]
 
+    @staticmethod
+    def capture_deletion() -> list[Pattern[str]]:
+        """Passthrough for capture deletion by UUID."""
+        return [
+            re.compile(
+                rf"{hostname_and_port}{API_PATH}{API_TARGET_VERSION}{Endpoints.CAPTURES}/{uuid_v4_regex}/"
+            )
+            for hostname_and_port in passthru_hostnames
+        ]
+
     @classmethod
     def capture_listing(cls) -> list[str]:
         """Passthrough for capture creation and listing."""

--- a/sdk/tests/integration/test_captures.py
+++ b/sdk/tests/integration/test_captures.py
@@ -425,6 +425,37 @@ def test_capture_reading_drf(integration_client: Client) -> None:
     )
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures("_integration_setup_teardown")
+@pytest.mark.usefixtures("_capture_test")
+@pytest.mark.usefixtures("_without_responses")
+@pytest.mark.parametrize(
+    "_without_responses",
+    argvalues=[
+        [
+            *PassthruEndpoints.capture_deletion(),
+        ]
+    ],
+    indirect=True,
+)
+def test_capture_deletion(integration_client: Client) -> None:
+    """Tests deleting a capture."""
+
+    # ARRANGE
+    # Create a capture to delete
+    capture = integration_client.captures.create(
+        top_level_dir=PurePosixPath("/test/capture/directory"),
+        capture_type=CaptureType.DigitalRF,
+    )
+
+    # ACT
+    result = integration_client.captures.delete(capture_uuid=capture.uuid)
+
+    # ASSERT
+    assert result is True, "Capture deletion should return True"
+    # Additional assertions can be added to verify the capture no longer exists
+
+
 def _upload_assets(
     integration_client: Client,
     sds_path: Path | PurePosixPath,

--- a/sdk/tests/ops/test_captures.py
+++ b/sdk/tests/ops/test_captures.py
@@ -281,3 +281,41 @@ def test_capture_string_representation(sample_capture_data: dict[str, Any]) -> N
     assert f"files={len(capture.files)}" in capture_str
     assert capture.__class__.__name__ in capture_repr
     assert str(capture.uuid) in capture_repr
+
+
+def test_delete_capture(client: Client, responses: responses.RequestsMock) -> None:
+    """Test deleting a capture."""
+    # ARRANGE
+    client.dry_run = DRY_RUN
+    capture_uuid = uuidlib.uuid4()
+
+    # Mock response
+    responses.add(
+        method=responses.DELETE,
+        url=get_captures_endpoint(client, capture_id=capture_uuid.hex),
+        status=204,
+    )
+
+    # ACT
+    result = client.captures.delete(capture_uuid=capture_uuid)
+
+    # ASSERT
+    assert result is True
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.method == "DELETE"
+    assert responses.calls[0].request.url == get_captures_endpoint(
+        client, capture_id=capture_uuid.hex
+    )
+
+
+def test_delete_capture_dry_run(client: Client) -> None:
+    """Test deleting a capture in dry run mode."""
+    # ARRANGE
+    client.dry_run = True
+    capture_uuid = uuidlib.uuid4()
+
+    # ACT
+    result = client.captures.delete(capture_uuid=capture_uuid)
+
+    # ASSERT
+    assert result is True  # Dry run should simulate success


### PR DESCRIPTION
- **Gateway**
    - Added more detailed information for API consumers regarding capture conflicts.
    - Updated `make test` to ignore the empty pytest suite, letting it run the actual tests.
- **SDK:**
    - Fixed tests to align with recent capture creation constraints.
    - Capture UUIDs for deletion may be passed as positional argument.
    - Ensured `sds_path` in `list_files` is a `PurePosixPath`.
    - Improved pagination-related docstrings.
    - Added build acceptance checks for capture deletion.
    - Implemented capture deletion functionality + local and integration tests.
