### PR TITLE
Increasing max connections default for postgres

### DIFF
--- a/gateway/compose.production.yaml
+++ b/gateway/compose.production.yaml
@@ -143,6 +143,7 @@ services:
             dockerfile: ./compose/production/postgres/Dockerfile
         image: sds-gateway-prod-postgres
         container_name: sds-gateway-prod-postgres
+        command: -c 'max_connections=300'
         volumes:
             - sds-gateway-prod-postgres-data:/var/lib/postgresql/data
             - sds-gateway-prod-postgres-data-backups:/backups


### PR DESCRIPTION
[SFDS-188](https://crc-dev.atlassian.net/browse/SFDS-188)

Preventing DB from hitting the max threshold in prod, where we use more workers.
