### PR TITLE
Lp/gwy drf queryset

### DIFF
--- a/gateway/makefile
+++ b/gateway/makefile
@@ -43,13 +43,17 @@ restart:
 	@echo "Restarting sds-gateway"
 	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) restart $(ARGS)
 
+serve-coverage:
+	@echo "Serving coverage reports"
+	@COMPOSE_FILE=$(COMPOSE_FILE) uv run -m http.server 1313 -d ./htmlcov
+
 test:
 
-	@echo "Validating templates"
-	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) python manage.py validate_templates
+	@# @echo "Validating templates"
+	@# @COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) python manage.py validate_templates
 
 	@echo "Running tests"
-	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) pytest
+	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) pytest $(ARGS)
 
 	@# Django's test runner: obsolete, subset of pytest tests, left as reference.
 	@# @COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) python manage.py test --no-input --force-color --verbosity 0

--- a/gateway/makefile
+++ b/gateway/makefile
@@ -45,7 +45,7 @@ restart:
 
 serve-coverage:
 	@echo "Serving coverage reports"
-	@COMPOSE_FILE=$(COMPOSE_FILE) uv run -m http.server 1313 -d ./htmlcov
+	@COMPOSE_FILE=$(COMPOSE_FILE) python -m http.server 1313 -d ./htmlcov
 
 test:
 

--- a/gateway/makefile
+++ b/gateway/makefile
@@ -49,8 +49,8 @@ serve-coverage:
 
 test:
 
-	@# @echo "Validating templates"
-	@# @COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) python manage.py validate_templates
+	@echo "Validating templates"
+	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) python manage.py validate_templates
 
 	@echo "Running tests"
 	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) pytest $(ARGS)

--- a/gateway/sds_gateway/api_methods/helpers/reconstruct_file_tree.py
+++ b/gateway/sds_gateway/api_methods/helpers/reconstruct_file_tree.py
@@ -185,18 +185,15 @@ def _get_filenames_of_interest_for_capture(
             else:
                 msg += "No RF data end file found.\n"
             if first_dmd_data_file_name:
+                # this one is optional
                 filenames_of_interest.add(first_dmd_data_file_name)
-            else:
-                msg += "No metadata start file found.\n"
 
             if msg:
-                msg = f"""
-                    Some files that are required to get sample bounds for DRF captures
-                    are missing:
-                    {msg.strip()}
-                    Metadata extraction will fail without these file contents
-                    loaded correctly.
-                """
+                msg = (
+                    "Some files that are required to get sample bounds for DRF captures"
+                    f"are missing:\n{msg.strip()}\nMetadata extraction will fail "
+                    "without these file contents loaded correctly."
+                )
                 log.warning(msg)
                 raise ValueError(msg)
 

--- a/gateway/sds_gateway/api_methods/helpers/reconstruct_file_tree.py
+++ b/gateway/sds_gateway/api_methods/helpers/reconstruct_file_tree.py
@@ -1,3 +1,5 @@
+# ruff: noqa: ERA001
+
 import json
 import uuid
 from pathlib import Path
@@ -12,10 +14,12 @@ from sds_gateway.api_methods.models import File
 from sds_gateway.api_methods.utils.minio_client import get_minio_client
 from sds_gateway.users.models import User
 
+RH_DEFAULT_EXTENSION = ".rh.json"
+
 
 def _is_metadata_file(file_name: str, capture_type: CaptureType) -> bool:
     if capture_type == CaptureType.RadioHound:
-        return file_name.endswith(".rh.json")
+        return file_name.endswith(RH_DEFAULT_EXTENSION)
 
     if capture_type == CaptureType.DigitalRF:
         # DigitalRF metadata files contain "properties" in the name
@@ -33,14 +37,14 @@ def _get_drf_sample_file_name_bounds(
     """Get the timestamp of the first file in the given directory."""
     # get the rf data file names
     # all rf data files start with rf@ per the notes here:
-    # https://github.com/MITHaystack/digital_rf/blob/master/python/digital_rf/digital_rf_hdf5.py#L793 #noqa: E501
+    # https://github.com/MITHaystack/digital_rf/blob/master/python/digital_rf/digital_rf_hdf5.py#L793
     drf_file_objs = file_queryset.filter(
         name__startswith="rf@",
     )
 
     # sort the rf data file objs
     # use the same sorting as in ilsdrf():
-    # https://github.com/MITHaystack/digital_rf/blob/ca7d715f27d527a11125dbd4c5971627c30efe31/python/digital_rf/list_drf.py#L253 #noqa: E501
+    # https://github.com/MITHaystack/digital_rf/blob/ca7d715f27d527a11125dbd4c5971627c30efe31/python/digital_rf/list_drf.py#L253
     # should return the lowest timestamp first
     drf_file_objs = drf_file_objs.order_by("name")
 
@@ -60,7 +64,7 @@ def _get_dmd_first_sample_file_name(file_queryset: QuerySet[File]) -> str | None
     """Get the first sample file name for a DigitalRF capture."""
     # follows the process for getting the bounds from
     # DigitalMetadataReader read_flatdict() function
-    # https://github.com/MITHaystack/digital_rf/blob/ca7d715f27d527a11125dbd4c5971627c30efe31/python/digital_rf/digital_metadata.py#L627 #noqa: E501
+    # https://github.com/MITHaystack/digital_rf/blob/ca7d715f27d527a11125dbd4c5971627c30efe31/python/digital_rf/digital_metadata.py#L627
     dmd_file_objs = file_queryset.filter(
         name__startswith="metadata@",
     )
@@ -77,57 +81,158 @@ def _get_dmd_first_sample_file_name(file_queryset: QuerySet[File]) -> str | None
     return dmd_file_objs.first().name
 
 
+def _get_list_of_capture_files(
+    capture_type: CaptureType,
+    virtual_top_dir: Path,
+    owner: User,
+    drf_channel: str | None = None,
+    rh_scan_group: uuid.UUID | None = None,
+    target_dir: Path | None = None,
+    *,
+    verbose: bool = False,
+) -> QuerySet[File]:
+    """Returns the queryset of files to fetch from MinIO."""
+    owned_files_filter_by_capture_type = {
+        # matches .h5, .hdf, .hdf5, .he5 (case-insensitive)
+        CaptureType.DigitalRF: Q(
+            owner=owner,
+            name__iregex=r"\.(hdf5?|he?5)$",
+            directory__startswith=str(virtual_top_dir).rstrip("/"),
+        ),
+        CaptureType.RadioHound: Q(
+            owner=owner,
+            name__endswith=RH_DEFAULT_EXTENSION,
+            directory__startswith=str(virtual_top_dir).rstrip("/"),
+        ),
+    }
+
+    # get all files owned by user in this directory
+    user_file_queryset = File.objects.filter(
+        owner=owner,
+        is_deleted=False,
+    ).filter(
+        owned_files_filter_by_capture_type[capture_type],
+    )
+
+    # TODO: filter files by depth to avoid fetching too many files
+
+    if verbose:
+        log.debug(
+            f"Found {len(user_file_queryset)} files for {owner} in "
+            f"{virtual_top_dir} for {capture_type} type",
+        )
+    if not user_file_queryset.exists():
+        return user_file_queryset.none()
+
+    match capture_type:
+        case CaptureType.DigitalRF:
+            assert drf_channel, "drf_channel must be provided for DigitalRF captures"
+            if verbose:
+                # log each file in the queryset for debugging and traceability
+                for file_entry in user_file_queryset:
+                    log.warning(
+                        f"File entry: name={file_entry.name}, "
+                        f"directory={file_entry.directory}, id={file_entry.id}",
+                    )
+            # filter files where the channel name appears as a directory component
+            filtered_files = user_file_queryset.filter(
+                directory__regex=rf".*/{drf_channel}(/.*)?$",
+            )
+            if verbose:
+                # log each file in the queryset for debugging and traceability
+                for file_entry in filtered_files:
+                    log.warning(
+                        f"File entry: name={file_entry.name}, "
+                        f"directory={file_entry.directory}, id={file_entry.id}",
+                    )
+        case _:
+            filtered_files = user_file_queryset
+
+    if verbose:
+        log.debug(f"Filtered {len(filtered_files)} files")
+
+    return filtered_files
+
+
+def _get_filenames_of_interest_for_capture(
+    capture_type: CaptureType,
+    file_queryset: QuerySet[File],
+    *,
+    verbose: bool = False,
+) -> set[str]:
+    """Get the set of filenames that are of interest for reconstruction."""
+    # TODO: consider changing this to return a queryset instead of a set of file names
+    filenames_of_interest = set()
+
+    # if capture type is digital rf, get the first and last rf data file names
+    match capture_type:
+        case CaptureType.DigitalRF:
+            first_drf_data_file_name = None
+            last_drf_data_file_name = None
+            first_dmd_data_file_name = None
+            first_drf_data_file_name, last_drf_data_file_name = (
+                _get_drf_sample_file_name_bounds(file_queryset)
+            )
+            first_dmd_data_file_name = _get_dmd_first_sample_file_name(file_queryset)
+
+            msg = ""
+            if first_drf_data_file_name:
+                filenames_of_interest.add(first_drf_data_file_name)
+            else:
+                msg += "No RF data start file found.\n"
+            if last_drf_data_file_name:
+                filenames_of_interest.add(last_drf_data_file_name)
+            else:
+                msg += "No RF data end file found.\n"
+            if first_dmd_data_file_name:
+                filenames_of_interest.add(first_dmd_data_file_name)
+            else:
+                msg += "No metadata start file found.\n"
+
+            if msg:
+                msg = f"""
+                    Some files that are required to get sample bounds for DRF captures
+                    are missing:
+                    {msg.strip()}
+                    Metadata extraction will fail without these file contents
+                    loaded correctly.
+                """
+                log.warning(msg)
+                raise ValueError(msg)
+
+    if verbose:
+        log.debug(
+            f"Got {len(filenames_of_interest)} filenames of interest ({capture_type})",
+        )
+
+    return filenames_of_interest
+
+
 def _check_fetch_conditions(
     file_name: str,
     capture_type: CaptureType,
-    file_queryset: QuerySet[File],
+    filenames_of_interest: set[str],
 ) -> bool:
     """
-    Check if the contents of the given files should be added
-    to the given directory from MinIO.
+    Check if the contents of the given files of interest should be fetched from MinIO.
+
+    This exists because not all files of interest will have their contents fetched. For
+    example, metadata files are interesting for indexing and lightweight, but raw data
+    files may make up most of storage, but are not needed for indexing.
 
     Args:
-        file_name: The name of the file to check
-        capture_type: The type of capture
-        file_queryset: The queryset of files to get the bounds
-        and first sample file name from
+        file_name:              The name of the file to check
+        capture_type:           The type of capture
+        filenames_of_interest:  The set of file names that are of interest
     Returns:
-        True if the file should be fetched, False otherwise
+        True if the file contents should be fetched, False otherwise
     """
-    first_drf_data_file_name = None
-    last_drf_data_file_name = None
-    first_dmd_data_file_name = None
 
-    # if capture type is digital rf, get the first and last rf data file names
-    if capture_type == CaptureType.DigitalRF:
-        first_drf_data_file_name, last_drf_data_file_name = (
-            _get_drf_sample_file_name_bounds(file_queryset)
-        )
-        first_dmd_data_file_name = _get_dmd_first_sample_file_name(file_queryset)
-
-        if None in (
-            first_drf_data_file_name,
-            last_drf_data_file_name,
-            first_dmd_data_file_name,
-        ):
-            msg = f"""
-                Some files that are required to get sample bounds for DRF captures
-                are missing:
-                RF data start file: {first_drf_data_file_name or "Not found"}
-                RF data end file: {last_drf_data_file_name or "Not found"}
-                Metadata start file: {first_dmd_data_file_name or "Not found"}
-                Metadata extraction will fail without these file contents
-                loaded correctly.
-            """
-            log.error(msg)
-            raise ValueError(msg)
-
-    match (file_name, _is_metadata_file(file_name, capture_type)):
-        case (name, _) if name in (
-            first_drf_data_file_name,
-            last_drf_data_file_name,
-            first_dmd_data_file_name,
-        ):
+    match (
+        file_name,
+        _is_metadata_file(file_name=file_name, capture_type=capture_type),
+    ):
+        case (name, _) if name in filenames_of_interest:
             return True
         case (_, True):
             return True
@@ -139,7 +244,8 @@ def reconstruct_tree(
     target_dir: Path,
     virtual_top_dir: Path,
     owner: User,
-    drf_capture_type: CaptureType,
+    capture_type: CaptureType,
+    drf_channel: str | None = None,
     rh_scan_group: uuid.UUID | None = None,
     *,
     verbose: bool = False,
@@ -167,42 +273,37 @@ def reconstruct_tree(
         msg = f"{target_dir=} must be a directory."
         raise ValueError(msg)
 
+    capture_files = _get_list_of_capture_files(
+        capture_type=capture_type,
+        virtual_top_dir=virtual_top_dir,
+        owner=owner,
+        drf_channel=drf_channel,
+        rh_scan_group=rh_scan_group,
+        target_dir=target_dir,
+        verbose=verbose,
+    )
+
     reconstructed_root = Path(f"{target_dir}/{virtual_top_dir}").resolve()
     assert reconstructed_root.is_relative_to(
         target_dir,
     ), f"{reconstructed_root=} must be a subdirectory of {target_dir=}"
 
-    owned_files_filter_by_capture_type = {
-        CaptureType.DigitalRF: Q(
-            owner=owner,
-            directory__startswith=str(virtual_top_dir).rstrip("/"),  # parent dir match
-        ),
-        CaptureType.RadioHound: Q(
-            owner=owner,
-            name__endswith=".rh.json",
-            directory__startswith=str(virtual_top_dir).rstrip("/"),  # parent dir match
-        ),
-    }
-    # get all files owned by user in this directory
-    user_file_queryset = File.objects.filter(
-        owner=owner,
-        is_deleted=False,
-    )
-    owned_files = {
-        owned_file.name: owned_file
-        for owned_file in user_file_queryset.filter(
-            owned_files_filter_by_capture_type[drf_capture_type],
-        )
-    }
-    if not owned_files:
+    if not capture_files:
         msg = f"No files found for {owner=} in {virtual_top_dir=}"
         log.warning(msg)
         return reconstructed_root, []
 
-    # Reconstruct the tree
     if verbose:
-        log.debug(f"Reconstructing tree with {len(owned_files)} files")
-    for file_obj in owned_files.values():
+        log.debug(f"Reconstructing tree with {len(capture_files)} files")
+
+    filenames_of_interest = _get_filenames_of_interest_for_capture(
+        capture_type=capture_type,
+        file_queryset=capture_files,
+        verbose=verbose,
+    )
+
+    # reconstruct the tree
+    for file_obj in capture_files:
         local_file_path = Path(
             f"{target_dir}/{file_obj.directory}/{file_obj.name}",
             # must be str concatenation to handle file_obj.directory being absolute
@@ -218,9 +319,9 @@ def reconstruct_tree(
         # we need to download the file contents from MinIO
         # else, create a dummy file with the file name
         fetch_file_contents = _check_fetch_conditions(
-            file_obj.name,
-            drf_capture_type,
-            user_file_queryset,
+            file_name=file_obj.name,
+            capture_type=capture_type,
+            filenames_of_interest=filenames_of_interest,
         )
         if fetch_file_contents:
             minio_client.fget_object(
@@ -231,37 +332,58 @@ def reconstruct_tree(
         else:
             local_file_path.touch()
 
-    # If scan_group provided, filter files by it
+    # filter out rh files of different scan groups
+    # this needs to happen after the contents are fetched, unfortunately, because the
+    # scan group information is part of the file contents.
+    files_to_connect = _filter_files_after_fetching(
+        drf_capture_type=capture_type,
+        rh_scan_group=rh_scan_group,
+        reconstructed_root=reconstructed_root,
+        owned_files=capture_files,
+        verbose=verbose,
+    )
+
+    return reconstructed_root, files_to_connect
+
+
+def _filter_files_after_fetching(
+    drf_capture_type: CaptureType,
+    rh_scan_group: uuid.UUID | None,
+    reconstructed_root: Path,
+    owned_files: QuerySet[File],
+    *,
+    verbose: bool,
+) -> list[File]:
+    # only connect RH files of the same scan group
     if rh_scan_group and drf_capture_type == CaptureType.RadioHound:
         log.debug(f"Filtering RadioHound files by scan group {rh_scan_group}")
         files_to_connect = filter_rh_files_by_scan_group(
-            owned_files=owned_files,
+            rh_capture_files=owned_files,
             scan_group=rh_scan_group,
             tmp_dir_path=reconstructed_root,
             verbose=verbose,
         )
     else:
-        files_to_connect = list(owned_files.values())
-
-    return reconstructed_root, files_to_connect
+        files_to_connect = list(owned_files)
+    return files_to_connect
 
 
 def filter_rh_files_by_scan_group(
-    owned_files: dict[str, File],
+    rh_capture_files: QuerySet[File],
     scan_group: uuid.UUID,
     tmp_dir_path: Path,
-    extension: str = ".rh.json",
+    extension: str = RH_DEFAULT_EXTENSION,
     *,
     verbose: bool = False,
 ) -> list[File]:
     """Filters RH files that belong to the given scan group.
 
     Args:
-        owned_files:    Maps file names to File objects for metadata tracking
-        scan_group:     UUID to search for in the file content
-        tmp_dir_path:   Directory to search the file contents
-        extension:      File extension to filter by
-        verbose:        Whether to log debug info
+        rh_capture_files:   QuerySet of owned RH files to filter
+        scan_group:         UUID to search for in the file content
+        tmp_dir_path:       Directory to search the file contents
+        extension:          File extension to filter by
+        verbose:            Whether to log debug info
     Returns:
         List of RH File's that belong to the scan group
     """
@@ -273,6 +395,7 @@ def filter_rh_files_by_scan_group(
             log.debug(path)
     pattern = f"*{extension}"
     rh_glob = tmp_dir_path.rglob(pattern)
+    owned_files_map = {owned_file.name: owned_file for owned_file in rh_capture_files}
     for file_path in rh_glob:
         file_count += 1
         try:
@@ -280,9 +403,9 @@ def filter_rh_files_by_scan_group(
                 content = json.load(candidate_file)
             if (
                 content.get("scan_group") == str(scan_group)
-                and file_path.name in owned_files
+                and file_path.name in owned_files_map
             ):
-                matching_files.append(owned_files[file_path.name])
+                matching_files.append(owned_files_map[file_path.name])
             elif verbose:
                 log.debug(f"Skipping {file_path.name} for scan group '{scan_group}'")
         except (json.JSONDecodeError, KeyError) as e:
@@ -296,11 +419,18 @@ def filter_rh_files_by_scan_group(
     elif not matching_files:
         msg = f"No files found out of {file_count} files for scan group '{scan_group}'"
         log.warning(msg)
+    elif verbose:
+        log.debug(
+            f"Found {len(matching_files)} / {file_count} for scan group '{scan_group}'",
+        )
 
     return matching_files
 
 
-def find_rh_metadata_file(tmp_dir_path: Path, extension: str = ".rh.json") -> Path:
+def find_rh_metadata_file(
+    tmp_dir_path: Path,
+    extension: str = RH_DEFAULT_EXTENSION,
+) -> Path:
     """Finds the RadioHound metadata file in the given directory."""
     for local_file in tmp_dir_path.iterdir():
         if local_file.name.endswith(extension):

--- a/gateway/sds_gateway/api_methods/helpers/reconstruct_file_tree.py
+++ b/gateway/sds_gateway/api_methods/helpers/reconstruct_file_tree.py
@@ -132,7 +132,7 @@ def _get_list_of_capture_files(
                 for file_entry in user_file_queryset:
                     log.warning(
                         f"File entry: name={file_entry.name}, "
-                        f"directory={file_entry.directory}, id={file_entry.id}",
+                        f"directory={file_entry.directory}",
                     )
             # filter files where the channel name appears as a directory component
             filtered_files = user_file_queryset.filter(
@@ -143,7 +143,7 @@ def _get_list_of_capture_files(
                 for file_entry in filtered_files:
                     log.warning(
                         f"File entry: name={file_entry.name}, "
-                        f"directory={file_entry.directory}, id={file_entry.id}",
+                        f"directory={file_entry.directory}",
                     )
         case _:
             filtered_files = user_file_queryset

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -231,6 +231,11 @@ class CaptureViewSet(viewsets.ViewSet):
                 {"detail": "The provided `top_level_dir` is invalid."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        if capture_type == CaptureType.DigitalRF and not drf_channel:
+            return Response(
+                {"detail": "The `channel` field is required for DigitalRF captures."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         requester = cast("User", request.user)
 

--- a/gateway/sds_gateway/api_methods/views/capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/views/capture_endpoints.py
@@ -141,7 +141,8 @@ class CaptureViewSet(viewsets.ViewSet):
                 target_dir=Path(temp_dir),
                 virtual_top_dir=top_level_dir,
                 owner=requester,
-                drf_capture_type=capture.capture_type,
+                capture_type=capture.capture_type,
+                drf_channel=drf_channel,
                 rh_scan_group=rh_scan_group,
                 verbose=True,
             )

--- a/sdk/tests/integration/test_captures.py
+++ b/sdk/tests/integration/test_captures.py
@@ -628,7 +628,6 @@ def test_capture_reading_drf(
     # ASSERT
 
     # basic capture information
-    log.error(f"{read_capture!s}")
     assert read_capture.files, "Expected a list of files associated to this capture"
     assert read_capture.uuid == capture.uuid, "Capture UUID should match"
     assert read_capture.capture_type == CaptureType.DigitalRF


### PR DESCRIPTION
[SFDS-201](https://crc-dev.atlassian.net/browse/SFDS-201)

+ Reduced the queryset used to create DRF captures and prevent incorrect selection of metadata files.
	+ Filtering `.h5`, `.hdf`, `.hdf5`, and `.he5` (case-insensitive) for DRF captures.
	+ Filtering files that match targeted channel.
+ Making `metadata@` files optional for DRF capture creation.
+ Refactored file tree reconstruction to reduce scope.
