### PR TITLE
Controlling default for account approval with settings

### DIFF
--- a/gateway/.envs/example/django.env
+++ b/gateway/.envs/example/django.env
@@ -31,5 +31,6 @@ SVI_SERVER_API_KEY=
 SENTRY_DSN=https://00000000000000000000000000000000@o000000.ingest.us.sentry.io/0000000000000000
 
 # BUSINESS LOGIC
+# ------------------------------------------------------------------------------
 # Recommended `False` in production
 SDS_NEW_USERS_APPROVED_ON_CREATION=True

--- a/gateway/.envs/example/django.env
+++ b/gateway/.envs/example/django.env
@@ -1,24 +1,24 @@
 # -------------------------------------------------------
 # ====================== LOCAL ENV ======================
-# General
+# GENERAL
 # ------------------------------------------------------------------------------
 USE_DOCKER=yes
 HOSTNAME=localhost:8000
 API_VERSION=v1
 API_KEY=
 
-# OAuth
+# AUTH0
 # ------------------------------------------------------------------------------
 # Set these from your Auth0 application settings
 AUTH0_DOMAIN=https://dev-XXXXXXXXXX.us.auth0.com
 CLIENT_ID=
 CLIENT_SECRET=
 
-# Redis
+# REDIS
 # ------------------------------------------------------------------------------
 REDIS_URL=redis://redis:6379/0
 
-# SpectrumX Visualizations Interface Authentication Token
+# SPECTRUMX VISUALIZATIONS INTERFACE
 # ------------------------------------------------------------------------------
 # (this is needed by the SVI to communicate with the SDS to pull user's SDK API tokens;
 # the below two environment variables should also be set in the SVI's environment variables)
@@ -26,6 +26,10 @@ SVI_SERVER_EMAIL=svi-server@spectrumx.crc.nd.edu
 # limit to 40 characters
 SVI_SERVER_API_KEY=
 
-# Sentry
+# SENTRY
 # ------------------------------------------------------------------------------
 SENTRY_DSN=https://00000000000000000000000000000000@o000000.ingest.us.sentry.io/0000000000000000
+
+# BUSINESS LOGIC
+# Recommended `False` in production
+SDS_NEW_USERS_APPROVED_ON_CREATION=True

--- a/gateway/.envs/example/django.prod-example.env
+++ b/gateway/.envs/example/django.prod-example.env
@@ -1,6 +1,6 @@
 # 🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
 # ====================== PRODUCTION ENV ======================
-# General
+# GENERAL
 # ------------------------------------------------------------------------------
 # DJANGO_READ_DOT_ENV_FILE=True
 DJANGO_SETTINGS_MODULE=config.settings.production
@@ -8,19 +8,19 @@ DJANGO_SECRET_KEY=
 DJANGO_ADMIN_URL=
 DJANGO_ALLOWED_HOSTS=localhost,sds.crc.nd.edu
 
-# Security
+# SECURITY
 # ------------------------------------------------------------------------------
 # Traefik already redirects users, so we can disable it here:
 DJANGO_SECURE_SSL_REDIRECT=False
 
-# OAuth
+# OAUTH
 # ------------------------------------------------------------------------------
 # Set these from your Auth0 application settings
 AUTH0_DOMAIN=https://dev-XXXXXXXXXX.us.auth0.com
 CLIENT_ID=
 CLIENT_SECRET=
 
-# Email
+# EMAIL
 # ------------------------------------------------------------------------------
 DJANGO_SERVER_EMAIL=
 
@@ -28,27 +28,28 @@ MAILGUN_API_KEY=
 MAILGUN_DOMAIN=
 
 
-# django-allauth
+# DJANGO-ALLAUTH
 # ------------------------------------------------------------------------------
 DJANGO_ACCOUNT_ALLOW_REGISTRATION=True
 
-# Gunicorn
+# GUNICORN
 # ------------------------------------------------------------------------------
 WEB_CONCURRENCY=4
 
 
-# Redis
+# REDIS
 # ------------------------------------------------------------------------------
 REDIS_URL=redis://redis:6379/0
 
-# Celery
+# CELERY
 # ------------------------------------------------------------------------------
 
 # Flower
 CELERY_FLOWER_USER=
 CELERY_FLOWER_PASSWORD=
 
-# SpectrumX Visualizations Interface Authentication Token
+# SPECTRUMX VISUALIZATIONS INTERFACE
+# ------------------------------------------------------------------------------
 # (this is needed by the SVI to communicate with the SDS to pull user's SDK API tokens;
 # the below two environment variables should also be set in the SVI's environment variables)
 SVI_SERVER_EMAIL=svi-server@spectrumx.crc.nd.edu
@@ -56,4 +57,5 @@ SVI_SERVER_EMAIL=svi-server@spectrumx.crc.nd.edu
 SVI_SERVER_API_KEY=
 
 # BUSINESS LOGIC
+# ------------------------------------------------------------------------------
 SDS_NEW_USERS_APPROVED_ON_CREATION=False

--- a/gateway/.envs/example/django.prod-example.env
+++ b/gateway/.envs/example/django.prod-example.env
@@ -54,3 +54,6 @@ CELERY_FLOWER_PASSWORD=
 SVI_SERVER_EMAIL=svi-server@spectrumx.crc.nd.edu
 # limit to 40 characters
 SVI_SERVER_API_KEY=
+
+# BUSINESS LOGIC
+SDS_NEW_USERS_APPROVED_ON_CREATION=False

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -10,6 +10,7 @@ Metadata management and web interface for SDS.
     + [Local deploy](#local-deploy)
     + [Debugging tips](#debugging-tips)
     + [Production deploy](#production-deploy)
+    + [OpenSearch Query Tips](#opensearch-query-tips)
 
 ## Development environment
 
@@ -99,6 +100,7 @@ For the local deploy:
 
     ```bash
     docker exec -it sds-gateway-local-app python manage.py createsuperuser
+    # follow the prompts to set the username/email and password
     ```
 
 5. Access the web interface:
@@ -109,31 +111,27 @@ For the local deploy:
 
 6. Create the MinIO bucket:
 
-    Go to [localhost:9001](http://localhost:9001) and create a bucket named `spectrumx` with the credentials set in `minio.env`.
+    Go to [localhost:9001](http://localhost:9001) and create a bucket named `spectrumx` with the credentials set in `minio.env`. Optionally apply a storage quota to this bucket (you can modify it later if needed).
 
 7. Run the test suite:
 
+    For a local deploy:
+
     ```bash
-    docker exec -it sds-gateway-local-app python manage.py test --force-color
+    make test
     ```
 
-    Tests that run:
+    Template checks are also run as part of `make test`.
 
-    + `test_authenticate`
-    + `test_create_file`
-    + `test_retrieve_file`
-    + `test_retrieve_latest_file`
-    + `test_update_file`
-    + `test_delete_file`
-    + `test_file_contents_check`
-    + `test_download_file`
-    + `test_minio_health_check`
-    + `test_opensearch_health_check`
-
-8. Run template checks:
+    Alternatively, run them as:
 
     ```bash
     docker exec -it sds-gateway-local-app python manage.py validate_templates
+    docker exec -it sds-gateway-local-app pytest
+
+    # or with a production setting:
+    docker exec -it sds-gateway-prod-app python manage.py validate_templates
+    docker exec -it sds-gateway-prod-app pytest
     ```
 
 ## Debugging tips
@@ -150,17 +148,19 @@ For the local deploy:
 >
 > The production deploy uses the same host ports as the local one, just prefixed with `1`: (`8000` → `18000`).
 >
-> This means you can deploy both on the same machine e.g. dev/test/QA/staging and production as "local" and "prod"
-> respectively. This works as they also use different docker container, network, volume, and image names.
-> Traefik may be configured to route e.g. `sds.example.com` and `sds-dev.example.com` to the respective
-> the prod and local services respectively, using different container names and ports.
+> This means you can deploy both on the same machine e.g. dev/test/QA/staging and
+> production as "local" and "prod" respectively. This works as they also use different
+> docker container, network, volume, and image names. Traefik may be configured to route
+> e.g. `sds.example.com` and `sds-dev.example.com` to the prod and local services
+> respectively, using different container names and ports.
 
 Keep this in mind, however:
 
 > [!CAUTION]
 >
-> Due to the bind mounts of the local deploy, it's still recommended to use different copies of the
-> source code between a local and production deploy, even if they are on the same machine.
+> Due to the bind mounts of the local deploy, it's still recommended to use different
+> copies of the source code between a 'local' and 'production' deploy, even if they are
+> on the same machine.
 >
 
 1. **Set secrets**:

--- a/gateway/compose/local/django/start
+++ b/gateway/compose/local/django/start
@@ -2,15 +2,39 @@
 
 set -euo pipefail
 
-echo "Running database migrations..."
-python manage.py migrate
+APP_DIR="/app"
 
-echo "Initializing OpenSearch indices..."
-python manage.py init_indices || {
-    echo >&2 "Failed to initialize OpenSearch indices. Waiting for manual input."
+# logs a message and waits for manual input before exiting and terminating the container
+function echo_wait_and_quit() {
+    local message="$1"
+    echo >&2 "$message"
+    echo >&2 "Waiting for manual input before exiting..."
     sleep 3600
     exit 1
 }
 
-echo "Starting Uvicorn workers..."
-exec uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
+function main() {
+
+    pushd "${APP_DIR}" || {
+        echo_wait_and_quit "Failed to change directory to ${APP_DIR}."
+    }
+
+    echo "Applying database migrations..."
+    python manage.py migrate --noinput || {
+        echo_wait_and_quit "Failed to apply database migrations."
+    }
+
+    echo "Initializing OpenSearch indices..."
+    python manage.py init_indices || {
+        echo_wait_and_quit "Failed to initialize OpenSearch indices."
+    }
+
+    echo "Starting Uvicorn server..."
+    exec uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
+
+}
+
+main "$@" || {
+    echo >&2 "An error occurred while starting the Django application."
+    exit 1
+}

--- a/gateway/compose/production/django/start
+++ b/gateway/compose/production/django/start
@@ -2,15 +2,44 @@
 
 set -euo pipefail
 
-echo "Collecting static files..."
-python /app/manage.py collectstatic --noinput
+APP_DIR="/app"
 
-echo "Initializing OpenSearch indices..."
-python manage.py init_indices || {
-    echo >&2 "Failed to initialize OpenSearch indices. Waiting for manual input."
+# logs a message and waits for manual input before exiting and terminating the container
+function echo_wait_and_quit() {
+    local message="$1"
+    echo >&2 "$message"
+    echo >&2 "Waiting for manual input before exiting..."
     sleep 3600
     exit 1
 }
 
-echo "Starting Gunicorn server..."
-exec /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:18000 --chdir=/app -k uvicorn_worker.UvicornWorker
+function main() {
+
+    pushd "${APP_DIR}" || {
+        echo_wait_and_quit "Failed to change directory to ${APP_DIR}."
+    }
+
+    echo "Collecting static files..."
+    python manage.py collectstatic --noinput
+
+    echo "Applying database migrations..."
+    python manage.py migrate --noinput || {
+        echo_wait_and_quit "Failed to apply database migrations."
+    }
+
+    echo "Initializing OpenSearch indices..."
+    python manage.py init_indices || {
+        echo_wait_and_quit "Failed to initialize OpenSearch indices."
+    }
+
+    echo "Starting Gunicorn server..."
+    exec /usr/local/bin/gunicorn config.asgi \
+        --bind 0.0.0.0:18000 \
+        --chdir=/app -k uvicorn_worker.UvicornWorker
+
+}
+
+main "$@" || {
+    echo >&2 "An error occurred while starting the Django application."
+    exit 1
+}

--- a/gateway/config/settings/base.py
+++ b/gateway/config/settings/base.py
@@ -316,7 +316,7 @@ LOGGING: dict[str, Any] = {
     "root": {"level": "DEBUG", "handlers": ["console"]},
 }
 
-# Celery
+# CELERY
 # ------------------------------------------------------------------------------
 # if USE_TZ:
 #     # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-timezone
@@ -418,8 +418,8 @@ WEBPACK_LOADER: dict[str, dict[str, Any]] = {
 }
 # ------------------------------------------------------------------------------
 
-# Auth0 Stuff
-# Auth0 Configuration
+# AUTH0
+# ------------------------------------------------------------------------------
 SOCIALACCOUNT_PROVIDERS = {
     "auth0": {
         "AUTH0_URL": env("AUTH0_DOMAIN"),
@@ -442,3 +442,11 @@ SVI_SERVER_EMAIL: str = env(
     default="svi-server@spectrumx.crc.nd.edu",
 )
 SVI_SERVER_API_KEY: str = env("SVI_SERVER_API_KEY", default="svi-server-api-key")
+
+# BUSINESS LOGIC
+# ------------------------------------------------------------------------------
+# Whether new users are approved to generate API keys on creation or not.
+SDS_NEW_USERS_APPROVED_ON_CREATION: bool = env.bool(
+    "SDS_NEW_USERS_APPROVED_ON_CREATION",
+    default=False,
+)

--- a/gateway/config/settings/base.py
+++ b/gateway/config/settings/base.py
@@ -352,24 +352,24 @@ LOGGING: dict[str, Any] = {
 
 # django-allauth
 # ------------------------------------------------------------------------------
+# https://cookiecutter-django.readthedocs.io/en/latest/1-getting-started/settings.html
 ACCOUNT_ALLOW_REGISTRATION: bool = env.bool("DJANGO_ACCOUNT_ALLOW_REGISTRATION", True)
+
 # https://docs.allauth.org/en/latest/account/configuration.html
 ACCOUNT_AUTHENTICATION_METHOD: str = "email"
-# https://docs.allauth.org/en/latest/account/configuration.html
 ACCOUNT_EMAIL_REQUIRED: bool = True
-# https://docs.allauth.org/en/latest/account/configuration.html
 ACCOUNT_USERNAME_REQUIRED: bool = False
-# https://docs.allauth.org/en/latest/account/configuration.html
 ACCOUNT_USER_MODEL_USERNAME_FIELD: str | None = None
-# https://docs.allauth.org/en/latest/account/configuration.html
 ACCOUNT_EMAIL_VERIFICATION: str = "none"
-# https://docs.allauth.org/en/latest/account/configuration.html
 ACCOUNT_ADAPTER: str = "sds_gateway.users.adapters.AccountAdapter"
+
 # https://docs.allauth.org/en/latest/account/forms.html
-ACCOUNT_FORMS: dict[str, str] = {"signup": "sds_gateway.users.forms.UserSignupForm"}
+ACCOUNT_FORMS: dict[str, str] = {
+    "signup": "sds_gateway.users.forms.UserSignupForm",
+}
+
 # https://docs.allauth.org/en/latest/socialaccount/configuration.html
 SOCIALACCOUNT_ADAPTER: str = "sds_gateway.users.adapters.SocialAccountAdapter"
-# https://docs.allauth.org/en/latest/socialaccount/configuration.html
 SOCIALACCOUNT_FORMS: dict[str, str] = {
     "signup": "sds_gateway.users.forms.UserSocialSignupForm",
 }
@@ -422,6 +422,7 @@ WEBPACK_LOADER: dict[str, dict[str, Any]] = {
 # ------------------------------------------------------------------------------
 SOCIALACCOUNT_PROVIDERS = {
     "auth0": {
+        # https://docs.allauth.org/en/dev/socialaccount/providers/auth0.html#auth0
         "AUTH0_URL": env("AUTH0_DOMAIN"),
         "OAUTH_PKCE_ENABLED": True,
         "SCOPE": [

--- a/gateway/config/settings/local.py
+++ b/gateway/config/settings/local.py
@@ -49,13 +49,13 @@ EMAIL_BACKEND: str = env(
     default="django.core.mail.backends.console.EmailBackend",
 )
 
-# WhiteNoise
+# WHITENOISE
 # ------------------------------------------------------------------------------
 # http://whitenoise.evans.io/en/latest/django.html#using-whitenoise-in-development
 INSTALLED_APPS: list[str] = ["whitenoise.runserver_nostatic", *INSTALLED_APPS]
 
 
-# django-debug-toolbar
+# DJANGO-DEBUG-TOOLBAR
 # ------------------------------------------------------------------------------
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#prerequisites
 INSTALLED_APPS.extend(["debug_toolbar"])
@@ -100,7 +100,7 @@ if SENTRY_DSN:
         send_default_pii=False,
     )
 
-# Celery
+# CELERY
 # ------------------------------------------------------------------------------
 
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-eager-propagates
@@ -109,3 +109,11 @@ if SENTRY_DSN:
 # ------------------------------------------------------------------------------
 WEBPACK_LOADER["DEFAULT"]["CACHE"] = not DEBUG
 # ------------------------------------------------------------------------------
+
+# BUSINESS LOGIC
+# ------------------------------------------------------------------------------
+# Whether new users are approved to generate API keys on creation or not.
+SDS_NEW_USERS_APPROVED_ON_CREATION: bool = env.bool(
+    "SDS_NEW_USERS_APPROVED_ON_CREATION",
+    default=True,
+)

--- a/gateway/config/settings/production.py
+++ b/gateway/config/settings/production.py
@@ -188,10 +188,20 @@ if SENTRY_DSN:
         send_default_pii=False,
     )
 
-# django-rest-framework
+# DJANGO-REST-FRAMEWORK
 # -------------------------------------------------------------------------------
 # Tools that generate code samples can use SERVERS to point to the correct domain
 SPECTACULAR_SETTINGS["SERVERS"] = [
     {"url": "https://sds.crc.nd.edu", "description": "Production server"},
 ]
 # ------------------------------------------------------------------------------
+
+# ⚠️ Setting overrides for PRODUCTION
+
+# BUSINESS LOGIC
+# ------------------------------------------------------------------------------
+# Whether new users are approved to generate API keys on creation or not.
+SDS_NEW_USERS_APPROVED_ON_CREATION: bool = env.bool(
+    "SDS_NEW_USERS_APPROVED_ON_CREATION",
+    default=False,
+)

--- a/gateway/makefile
+++ b/gateway/makefile
@@ -23,7 +23,7 @@ build:
 
 up:
 	@echo "Starting sds-gateway"
-	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) up -d $(ARGS)
+	@COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) up -d --remove-orphans $(ARGS)
 
 logs:
 	@echo "Showing sds-gateway logs…"

--- a/gateway/makefile
+++ b/gateway/makefile
@@ -1,6 +1,7 @@
 # Build and manage a local deploy of the SDS Gateway - NOT PRODUCTION READY
 
-.PHONY: all redeploy build build-full up logs logs-once down restart test
+.PHONY: all redeploy build build-full up logs logs-once down pre-commit restart \
+	serve-coverage test update
 
 all: build up logs
 redeploy: build down up logs
@@ -57,3 +58,7 @@ test:
 
 	@# Django's test runner: obsolete, subset of pytest tests, left as reference.
 	@# @COMPOSE_FILE=$(COMPOSE_FILE) docker compose --env-file $(ENV_FILE) run $(APP_CONTAINER) python manage.py test --no-input --force-color --verbosity 0
+
+update:
+	@# uv sync --upgrade # re-enable when uv integration is done
+	uv run pre-commit autoupdate

--- a/gateway/sds_gateway/api_methods/utils/sds_files.py
+++ b/gateway/sds_gateway/api_methods/utils/sds_files.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from django.http import HttpRequest
 from loguru import logger as log
 from rest_framework.request import Request
 
@@ -8,7 +9,7 @@ from sds_gateway.users.models import User
 
 def sanitize_path_rel_to_user(
     unsafe_path: str,
-    request: Request | None = None,
+    request: Request | HttpRequest | None = None,
     user: User | None = None,
 ) -> Path | None:
     """Ensures a path is safe by making it relative to the user's root in SDS.

--- a/gateway/sds_gateway/users/forms.py
+++ b/gateway/sds_gateway/users/forms.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from allauth.account.forms import SignupForm
 from allauth.socialaccount.forms import SignupForm as SocialSignupForm
 from django import forms
+from django.conf import settings
 from django.contrib.auth import forms as admin_forms
 from django.core.exceptions import ValidationError
 from django.forms import EmailField
+from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
 from sds_gateway.api_methods.models import File
@@ -47,15 +49,28 @@ class UserSignupForm(SignupForm):
     Form that will be rendered on a user sign up section/screen.
     Default fields will be added automatically.
     Check UserSocialSignupForm for accounts created from social.
+    See ACCOUNT_FORMS in settings.
     """
+
+    def save(self, request: HttpRequest) -> User:
+        user = super().save(request)
+        user.is_approved = settings.SDS_NEW_USERS_APPROVED_ON_CREATION
+        user.save()
+        return user
 
 
 class UserSocialSignupForm(SocialSignupForm):
     """
     Renders the form when user has signed up using social accounts.
-    Default fields will be added automatically.
-    See UserSignupForm otherwise.
+    Default fields will be added automatically. See UserSignupForm otherwise.
+    See SOCIALACCOUNT_FORMS in settings.
     """
+
+    def save(self, request: HttpRequest) -> User:
+        user = super().save(request)
+        user.is_approved = settings.SDS_NEW_USERS_APPROVED_ON_CREATION
+        user.save()
+        return user
 
 
 class DatasetInfoForm(forms.Form):

--- a/gateway/sds_gateway/users/managers.py
+++ b/gateway/sds_gateway/users/managers.py
@@ -1,17 +1,23 @@
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import UserManager as DjangoUserManager
 from rest_framework_api_key.models import APIKeyManager
 
 if TYPE_CHECKING:
-    from .models import User  # noqa: F401
+    from .models import User
 
 
 class UserManager(DjangoUserManager["User"]):
     """Custom manager for the User model."""
 
-    def _create_user(self, email: str, password: str | None, **extra_fields):
+    def _create_user(
+        self,
+        email: str,
+        password: str | None,
+        **extra_fields,
+    ) -> "User":
         """
         Create and save a user with the given email and password.
         """
@@ -24,12 +30,25 @@ class UserManager(DjangoUserManager["User"]):
         user.save(using=self._db)
         return user
 
-    def create_user(self, email: str, password: str | None = None, **extra_fields):  # type: ignore[override]
+    def create_user(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        email: str,
+        password: str | None = None,
+        **extra_fields,
+    ) -> "User":  # type: ignore[override]
         extra_fields.setdefault("is_staff", False)
         extra_fields.setdefault("is_superuser", False)
-        return self._create_user(email, password, **extra_fields)
+        extra_fields.setdefault(
+            "is_approved", settings.SDS_NEW_USERS_APPROVED_ON_CREATION
+        )
+        return self._create_user(email=email, password=password, **extra_fields)
 
-    def create_superuser(self, email: str, password: str | None = None, **extra_fields):  # type: ignore[override]
+    def create_superuser(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        email: str,
+        password: str | None = None,
+        **extra_fields,
+    ) -> "User":
         extra_fields.setdefault("is_staff", True)
         extra_fields.setdefault("is_superuser", True)
 
@@ -40,7 +59,7 @@ class UserManager(DjangoUserManager["User"]):
             msg = "Superuser must have is_superuser=True."
             raise ValueError(msg)
 
-        return self._create_user(email, password, **extra_fields)
+        return self._create_user(email=email, password=password, **extra_fields)
 
 
 class APIKeyUserManager(APIKeyManager):

--- a/sdk/makefile
+++ b/sdk/makefile
@@ -7,7 +7,7 @@ TEST_MARKER_DEFAULT := not integration
 TEST_MARKER_INTEGRATION := integration
 
 .PHONY: all install gact pyright pre-commit test test-lowest test-verbose test-all test-integration \
-	test-integration-verbose serve-coverage clean update build publish
+	test-integration-verbose check-acceptance serve-coverage clean update build publish
 
 all: install test
 
@@ -107,11 +107,12 @@ clean:
 		./**/*.py.cover \
 		*.egg-info *.egg-info/
 
-# UPDATE
+# UPDATES
 update:
 	uv sync --upgrade
 	uv run pre-commit autoupdate
 
+# PACKAGING
 build:
 	uv build --no-cache
 	@echo -e "\n\t\033[32mRunning smoke tests on the built package\033[0m\n"
@@ -122,7 +123,6 @@ build:
 	tar -tvf dist/*.tar.gz | sort -k6
 	@echo -e "\n\t\033[34mTo publish it, run 'make publish'.\033[0m\n\n"
 
-# PUBLISH
 publish:
 	@if [ ! -d dist ]; then \
 		echo "Run 'make build' first."; \


### PR DESCRIPTION
[SFDS-203](https://crc-dev.atlassian.net/browse/SFDS-203)

+ Default value for the account approval flag for sign-ups is now controlled via a setting.
    + Default for development environment is `True` (accts are approved by default).
    + `False` otherwise.
+ Updated documentation on tests.
+ Running migrations in prod, before starting the server.
