### PR TITLE
Add new center_frequencies index field

### DIFF
--- a/gateway/sds_gateway/api_methods/helpers/extract_drf_metadata.py
+++ b/gateway/sds_gateway/api_methods/helpers/extract_drf_metadata.py
@@ -42,7 +42,12 @@ def key_in_dict_partial(
         The matched key if a partial match is found, None otherwise.
     """
     for dict_key in dict_keys:
-        if key in dict_key:
+        # make sure we are matching the last nested key directly
+        # e.g. "path.to.center_frequencies" -> "center_frequencies"
+        # avoid partial matches to the nested keys
+        # e.g. "center_freq" partially matching "path.to.center_frequencies"
+        last_nested_key = dict_key.split(".")[-1]
+        if key == last_nested_key:
             return dict_key
     return None
 

--- a/gateway/sds_gateway/api_methods/helpers/transforms.py
+++ b/gateway/sds_gateway/api_methods/helpers/transforms.py
@@ -91,9 +91,13 @@ class Transforms:
             "search_props.center_frequency": {
                 "source": """
                     if (ctx._source.capture_props != null &&
-                        ctx._source.capture_props.center_freq != null) {
+                        (ctx._source.capture_props.center_freq != null ||
+                        ctx._source.capture_props.center_frequencies != null) &&
+                        ctx._source.search_props.center_frequency == null) {
                         ctx._source.search_props.center_frequency =
-                            ctx._source.capture_props.center_freq;
+                            ctx._source.capture_props.center_freq != null ?
+                                ctx._source.capture_props.center_freq :
+                                ctx._source.capture_props.center_frequencies[0];
                     }
                 """.strip(),
                 "lang": "painless",

--- a/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
+++ b/gateway/sds_gateway/api_methods/tests/test_capture_endpoints.py
@@ -89,7 +89,7 @@ class CaptureTestCases(APITestCase):
 
         # Define test metadata
         self.drf_metadata = {
-            "center_freq": 2_000_000_000,
+            "center_frequencies": [2_000_000_000.0],
             "bandwidth": 20_000_000,
             "gain": 20.5,
         }
@@ -211,6 +211,7 @@ class CaptureTestCases(APITestCase):
                 f"Status {response_raw.status_code} != {status.HTTP_201_CREATED}"
             )
             response = response_raw.json()
+
             assert response["capture_props"] == self.drf_metadata, (
                 f"Props {response['capture_props']} != {self.drf_metadata}"
             )
@@ -223,6 +224,17 @@ class CaptureTestCases(APITestCase):
             )
             assert response["capture_type"] == CaptureType.DigitalRF, (
                 f"Capture type: {response['capture_type']} != {CaptureType.DigitalRF}"
+            )
+            assert isinstance(response["capture_props"]["center_frequencies"], list), (
+                "Center frequencies should be a list"
+            )
+            assert (
+                response["capture_props"]["center_frequencies"]
+                == self.drf_metadata["center_frequencies"]
+            ), (
+                "Center frequencies: "
+                f"{response['capture_props']['center_frequencies']} "
+                f"!= {self.drf_metadata['center_frequencies']}"
             )
 
     def test_create_rh_capture_201(self) -> None:
@@ -515,7 +527,7 @@ class CaptureTestCases(APITestCase):
         drf_capture = next(
             c for c in data["results"] if c["capture_type"] == CaptureType.DigitalRF
         )
-        assert drf_capture["capture_props"]["center_freq"] == center_freq
+        assert drf_capture["capture_props"]["center_frequencies"][0] == center_freq
 
         # get the RH capture
         rh_capture = next(

--- a/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
+++ b/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
@@ -99,6 +99,10 @@ drf_capture_metadata_schema = {
             "type": int,
             "description": "The center frequency of the capture.",
         },
+        "center_frequencies": {
+            "type": list[float],
+            "description": "The center frequencies (one per subchannel) of the capture.",
+        },
         "span": {
             "type": int,
             "description": "The span of the capture.",
@@ -222,6 +226,12 @@ drf_capture_index_mapping = {
         "type": "keyword",
     },
     "center_freq": {
+        "type": "double",
+    },
+    # opensearch does not have a special type for arrays
+    # instead any field can contain an array of values of the field type
+    # https://docs.opensearch.org/docs/latest/field-types/
+    "center_frequencies": {
         "type": "double",
     },
     "span": {

--- a/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
+++ b/gateway/sds_gateway/api_methods/utils/metadata_schemas.py
@@ -150,7 +150,7 @@ drf_capture_metadata_schema = {
         "epoch",
         "digital_rf_time_description",
         "digital_rf_version",
-        "center_freq",
+        "center_frequencies",
         "span",
         "gain",
         "bandwidth",


### PR DESCRIPTION
- Added center_frequencies to mapping (with note on how OpenSearch handles arrays)
- Updated metadata validation to prevent name collision with `center_freq` when extracting metadata
- Update transform for `search_props.center_frequency` to get first index of `center_frequencies`
- Update capture tests to use `center_frequencies` as default metadata field and add assertions to check the field is being passed and stored as array and transformed correctly