### PR TITLE
Dataset download task refactor to stream

### DIFF
--- a/gateway/sds_gateway/api_methods/helpers/download_file.py
+++ b/gateway/sds_gateway/api_methods/helpers/download_file.py
@@ -33,6 +33,7 @@ def download_file(target_file: File) -> bytes:
     client = get_minio_client()
     temp_file = None
     file_content = None
+    file_path = None
 
     try:
         # Create a temporary file to download to
@@ -58,8 +59,10 @@ def download_file(target_file: File) -> bytes:
         raise
     finally:
         # Clean up temporary file
-        if temp_file and Path(temp_file_path).exists():
+        if temp_file and temp_file_path and Path(temp_file_path).exists():
             try:
+                if file_path is None:
+                    file_path = Path(temp_file_path)
                 file_path.unlink()
             except OSError:
                 logger.warning("Could not delete temporary file: %s", temp_file_path)

--- a/gateway/sds_gateway/api_methods/tasks.py
+++ b/gateway/sds_gateway/api_methods/tasks.py
@@ -682,8 +682,8 @@ def _handle_timeout_exception(
 
 
 @shared_task(
-    time_limit=20 * 60, soft_time_limit=10 * 60
-)  # 20 min hard limit, 10 min soft limit
+    time_limit=30 * 60, soft_time_limit=25 * 60
+)  # 30 min hard limit, 25 min soft limit
 def send_item_files_email(  # noqa: C901
     item_uuid: str, user_id: str, item_type: str | ItemType
 ) -> dict:

--- a/gateway/sds_gateway/users/views.py
+++ b/gateway/sds_gateway/users/views.py
@@ -1034,19 +1034,6 @@ class GroupCapturesView(Auth0LoginRequiredMixin, FormSearchMixin, TemplateView):
                 {"success": False, "errors": {"non_field_errors": [str(e)]}},
                 status=500,
             )
-        except Exception:
-            logger.exception("Unexpected error in dataset creation")
-            return JsonResponse(
-                {
-                    "success": False,
-                    "errors": {
-                        "non_field_errors": [
-                            "An unexpected error occurred. Please try again."
-                        ]
-                    },
-                },
-                status=500,
-            )
 
     def _validate_dataset_form(self, request) -> JsonResponse | None:
         """Validate the dataset form and return error response if invalid."""

--- a/gateway/sds_gateway/users/views.py
+++ b/gateway/sds_gateway/users/views.py
@@ -1023,17 +1023,28 @@ class GroupCapturesView(Auth0LoginRequiredMixin, FormSearchMixin, TemplateView):
             # Add files to dataset
             self._add_files_to_dataset(dataset, selected_files)
 
-            # If this dataset is shared with users, also share any newly added captures
-            self._share_new_dataset_captures(dataset)
-
             # Return success response with redirect URL
             return JsonResponse(
                 {"success": True, "redirect_url": reverse("users:dataset_list")},
             )
 
         except (DatabaseError, IntegrityError) as e:
+            logger.exception("Database error in dataset creation")
             return JsonResponse(
                 {"success": False, "errors": {"non_field_errors": [str(e)]}},
+                status=500,
+            )
+        except Exception:
+            logger.exception("Unexpected error in dataset creation")
+            return JsonResponse(
+                {
+                    "success": False,
+                    "errors": {
+                        "non_field_errors": [
+                            "An unexpected error occurred. Please try again."
+                        ]
+                    },
+                },
                 status=500,
             )
 


### PR DESCRIPTION
- Increased the soft and hard time limits on the task to give more room for large downloads
- Refactored the download task to stream from MinIO directly into zip, skipping `download_file` operation, chunking the stream write into the zip file
- Broke out complex operations into helper functions to make it easier to read
- Update tests for download task to mock the MinIO streaming
- Add error handling and message to user for a timeout exception