### PR TITLE
No more support emails

### DIFF
--- a/gateway/config/settings/base.py
+++ b/gateway/config/settings/base.py
@@ -311,7 +311,7 @@ ADMIN_URL: str = "admin/"
 ADMINS: list[tuple[str, ...]] = [
     (
         """Center for Research Computing | University of Notre Dame""",
-        "crcsupport@nd.edu",
+        "crc-sds-list@nd.edu",
     ),
 ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#managers

--- a/gateway/config/settings/production.py
+++ b/gateway/config/settings/production.py
@@ -124,9 +124,6 @@ ADMIN_URL: str = env("DJANGO_ADMIN_URL")
 # https://docs.djangoproject.com/en/dev/ref/settings/#logging
 # See https://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error when DEBUG=False.
 LOGGING: dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -151,11 +148,11 @@ LOGGING: dict[str, Any] = {
     },
     "root": {"level": "DEBUG", "handlers": ["console"]},
     "loggers": {
-        "django.request": {
-            "handlers": ["mail_admins"],
-            "level": "ERROR",
-            "propagate": True,
-        },
+        # "django.request": {
+        #     "handlers": ["mail_admins"],  # will send emails to crc-sds-list@nd.edu
+        #     "level": "ERROR",
+        #     "propagate": True,
+        # },
         "django.security.DisallowedHost": {
             "level": "ERROR",
             "handlers": ["console", "mail_admins"],

--- a/gateway/locale/en_US/LC_MESSAGES/django.po
+++ b/gateway/locale/en_US/LC_MESSAGES/django.po
@@ -1,6 +1,6 @@
 # Translations for the SpectrumX Data System Gateway project
 # Copyright (C) Center for Research Computing | University of Notre Dame
-# Center for Research Computing | University of Notre Dame <crcsupport@nd.edu>, 2024.
+# Center for Research Computing | University of Notre Dame <crc-sds-list@nd.edu>, 2024.
 #
 #, fuzzy
 msgid ""

--- a/gateway/locale/fr_FR/LC_MESSAGES/django.po
+++ b/gateway/locale/fr_FR/LC_MESSAGES/django.po
@@ -1,6 +1,6 @@
 # Translations for the SpectrumX Data System Gateway project
 # Copyright (C) Center for Research Computing | University of Notre Dame
-# Center for Research Computing | University of Notre Dame <crcsupport@nd.edu>, 2024.
+# Center for Research Computing | University of Notre Dame <crc-sds-list@nd.edu>, 2024.
 #
 #, fuzzy
 msgid ""

--- a/gateway/locale/pt_BR/LC_MESSAGES/django.po
+++ b/gateway/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,6 +1,6 @@
 # Translations for the SpectrumX Data System Gateway project
 # Copyright (C) Center for Research Computing | University of Notre Dame
-# Center for Research Computing | University of Notre Dame <crcsupport@nd.edu>, 2024.
+# Center for Research Computing | University of Notre Dame <crc-sds-list@nd.edu>, 2024.
 #
 #, fuzzy
 msgid ""

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-    authors = [{ name = "Center for Research Computing | UND", email = "crcsupport@nd.edu" }]
+    authors = [{ name = "Center for Research Computing | UND", email = "crc-sds-list@nd.edu" }]
     dependencies = [
         "argon2-cffi>=23.1.0",
         "blake3>=0.4.1",


### PR DESCRIPTION
- Replaces support email address with the SDS email list address.
- Removes that email address as a log handler from production settings.
