### PR TITLE
Added jupyterhub-idle-culler service

### DIFF
--- a/jupyter/compose.local.yaml
+++ b/jupyter/compose.local.yaml
@@ -22,7 +22,7 @@ services:
             context: .
             dockerfile: ./compose/local/jupyter/Dockerfile
             args:
-                JUPYTERHUB_VERSION: latest
+                JUPYTERHUB_VERSION: 5.3.0-17
                 NB_UID: ${NB_UID:-1000}
                 NB_GID: ${NB_GID:-100}
                 DOCKER_GID: ${DOCKER_GID:-103}

--- a/jupyter/compose/local/jupyter/jupyterhub_config.py
+++ b/jupyter/compose/local/jupyter/jupyterhub_config.py
@@ -90,6 +90,40 @@ else:
     c.DummyAuthenticator.allowed_users = {"admin"}
     c.DummyAuthenticator.password = os.environ.get("JUPYTERHUB_DUMMY_PASSWORD", "admin")
 
+# === IDLE CULLER CONFIGURATION ===
+# Configure jupyterhub-idle-culler service following JupyterHub 2.0+ scopes
+
+# Define the idle culler service as a hub managed service
+c.JupyterHub.services = [
+    {
+        "name": "jupyterhub-idle-culler-service",
+        "command": [
+            "python",
+            "-m",
+            "jupyterhub_idle_culler",
+            "--timeout=30",  # 30s timeout for idle servers for testing
+            "--cull-every=10",  # Check every 10s for testing
+            "--remove-named-servers",  # Remove named servers
+            "--concurrency=10",  # Limit concurrent operations
+            "--max-age=60",  # Maximum age of 60s for testing.
+        ],
+    }
+]
+
+# Configure idle culler permissions using JupyterHub 2.0+ scopes
+c.JupyterHub.load_roles = [
+    {
+        "name": "jupyterhub-idle-culler-role",
+        "scopes": [
+            "list:users",  # Access to the user list API
+            "read:users:activity",  # Read users' last_activity field
+            "read:servers",  # Read users' servers field
+            "delete:servers",  # Stop users' servers and delete named servers
+        ],
+        "services": ["jupyterhub-idle-culler-service"],
+    }
+]
+
 # === OTHER CONFIGURATION ===
 
 # Configure proxy PID file to use writable directory

--- a/jupyter/compose/local/jupyter/requirements.txt
+++ b/jupyter/compose/local/jupyter/requirements.txt
@@ -9,3 +9,4 @@ ipywidgets
 spectrumx
 dockerspawner
 oauthenticator
+jupyterhub-idle-culler


### PR DESCRIPTION
For testing, in this PR, 

Culling time is set to 30s. 
Max age is 60s.
Checking intervals is set to 10s.

jupyterhub base image version is changed to 5.3.0-17 in jupyter/compose.local.yaml