### PR TITLE
Fix SDK pyright optional typing errors

### DIFF
--- a/sdk/src/spectrumx/utils.py
+++ b/sdk/src/spectrumx/utils.py
@@ -214,7 +214,7 @@ class LogContext:
 
     def __init__(self, **kwargs: Any) -> None:
         self._kwargs = kwargs
-        self._token: contextvars.Token[dict[str, Any]] | None = None
+        self._token: contextvars.Token[dict[str, Any] | None] | None = None
 
     def __enter__(self) -> None:
         current = (_log_context.get() or {}).copy()

--- a/sdk/tests/ops/test_datasets.py
+++ b/sdk/tests/ops/test_datasets.py
@@ -180,6 +180,7 @@ def test_get_gateway(client: Client, responses: responses.RequestsMock) -> None:
         status=200,
     )
     result = client.datasets.get(dataset_uuid)
+    assert result.uuid is not None
     assert result.uuid.hex == dataset_uuid.hex
     assert result.name == "test-dataset-from-gateway"
     assert len(responses.calls) == 1

--- a/sdk/tests/test_client.py
+++ b/sdk/tests/test_client.py
@@ -598,6 +598,7 @@ def test_download_single_file_sdserror(
     caplog.set_level(LogLevels.ERROR)
     file_info = files.generate_sample_file(uuid.uuid4())
     file_info.directory = PurePosixPath("remote/dir")
+    assert file_info.uuid is not None
     file_id_hex = file_info.uuid.hex
 
     # File info GET succeeds


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Typing and test-only assertions; no runtime behavior changes.
> 
> **Overview**
> Fixes **pyright** complaints around optional types in structured logging and tests.
> 
> In `LogContext`, `_token` is typed as `contextvars.Token[dict[str, Any] | None]` so it matches `_log_context` (`ContextVar[dict[str, Any] | None]`) and the value passed to `set()`.
> 
> Tests that use `.uuid.hex` after gateway or sample file setup now **assert `uuid is not None`** first (`test_get_gateway`, `test_download_single_file_sdserror`), satisfying narrow checks on optional `uuid` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c374ef0a12aabea185b59c2c268ea0bdbe041bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->