### PR TITLE
Publishing Gateway images to ghcr

### DIFF
--- a/.github/workflows/gwy-code-quality.yaml
+++ b/.github/workflows/gwy-code-quality.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
             UV_LINK_MODE: copy
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
 
             # this ubuntu-latest version ships node 18, which was causing issues
             # https://github.com/actions/setup-node#usage
@@ -48,12 +48,12 @@ jobs:
               uses: actions-rust-lang/setup-rust-toolchain@v1
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v8
               # https://github.com/marketplace/actions/astral-sh-setup-uv
 
             - name: Cache prek hooks
               id: cache-prek
-              uses: actions/cache@v5
+              uses: actions/cache@v6
               # https://github.com/actions/cache/blob/main/examples.md#python---pip
               with:
                   key: prek-gateway-${{ hashFiles('gateway/.pre-commit-config.yaml') }}
@@ -89,7 +89,7 @@ jobs:
                 # This is faster, saving some GH action minutes and dev time.
                 platform: [ubuntu-latest]
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
 
             # - name: Install dependencies
             #   run: sudo apt update && sudo apt install -y rsync
@@ -107,3 +107,50 @@ jobs:
             - name: Run tests
               run: just test
               working-directory: ./gateway
+
+    # Build and push Docker image to ghcr.io (only if checks pass, only on push, not PR)
+    gwy-build-and-push:
+        needs: [gwy-pre-commit, gwy-django-tests]
+        if: github.event_name == 'push' && github.ref_name == 'master' || github.event_name == 'push' && github.ref_name == 'main' || github.event_name == 'workflow_dispatch'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v4
+
+            - name: Log in to ghcr.io
+              uses: docker/login-action@v4
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract metadata
+              id: meta
+              uses: docker/metadata-action@v6
+              with:
+                  images: ghcr.io/spectrumx/sds-gateway
+                  tags: |
+                      type=sha,prefix=dev-,format=short
+                      type=raw,value=dev,enable={{ is_default_branch }}
+                  flavor: |
+                      latest=false
+
+            - name: Build and push
+              uses: docker/build-push-action@v7
+              with:
+                  context: gateway
+                  file: gateway/compose/production/django/Dockerfile
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  build-args: |
+                      GIT_COMMIT=${{ github.sha }}
+                      BUILD_ENVIRONMENT=production
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max

--- a/.github/workflows/gwy-code-quality.yaml
+++ b/.github/workflows/gwy-code-quality.yaml
@@ -111,7 +111,7 @@ jobs:
     # Build and push Docker image to ghcr.io (only if checks pass, only on push, not PR)
     gwy-build-and-push:
         needs: [gwy-pre-commit, gwy-django-tests]
-        if: github.event_name == 'push' && github.ref_name == 'master' || github.event_name == 'push' && github.ref_name == 'main' || github.event_name == 'workflow_dispatch'
+        if: (github.event_name == 'push' && (github.ref_name == 'master' || github.ref_name == 'main')) || (github.event_name == 'workflow_dispatch' && (github.ref_name == 'master' || github.ref_name == 'main'))
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/gwy-code-quality.yaml
+++ b/.github/workflows/gwy-code-quality.yaml
@@ -48,7 +48,7 @@ jobs:
               uses: actions-rust-lang/setup-rust-toolchain@v1
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
               # https://github.com/marketplace/actions/astral-sh-setup-uv
 
             - name: Cache prek hooks

--- a/.github/workflows/gwy-promote-stable.yaml
+++ b/.github/workflows/gwy-promote-stable.yaml
@@ -9,12 +9,38 @@ on:
                 type: string
 
 permissions:
+    contents: read
     packages: write
 
 jobs:
     gwy-promote:
         runs-on: ubuntu-latest
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+
+            - name: Verify commit is on default branch
+              env:
+                  SHA: ${{ inputs.commit_sha }}
+              run: |
+                  SHA_INPUT="${SHA}"
+                  # Resolve the short SHA to a full SHA
+                  if ! FULL_SHA=$(git rev-parse --verify "${SHA_INPUT}^{commit}" 2>/dev/null); then
+                      echo "ERROR: Could not resolve commit '${SHA_INPUT}' in this repository."
+                      echo "Ensure you are using a valid short SHA from the default branch (main)."
+                      exit 1
+                  fi
+                  echo "Resolved SHA: ${FULL_SHA}"
+                  # Verify the commit is an ancestor of the default branch (main)
+                  if ! git merge-base --is-ancestor "${FULL_SHA}" origin/main; then
+                      echo "ERROR: Commit ${SHA_INPUT} (${FULL_SHA}) is not an ancestor of the default branch (main)."
+                      echo "Only commits from the default branch can be promoted to stable."
+                      exit 1
+                  fi
+                  echo "✓ Commit ${SHA_INPUT} is a valid ancestor of main. Proceeding with promotion."
+
             - name: Log in to ghcr.io
               uses: docker/login-action@v4
               with:
@@ -23,8 +49,9 @@ jobs:
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Promote dev-<sha> to stable
+              env:
+                  SHA: ${{ inputs.commit_sha }}
               run: |
-                  SHA="${{ inputs.commit_sha }}"
                   REGISTRY="ghcr.io/spectrumx/sds-gateway"
                   docker buildx imagetools create \
                       --tag "${REGISTRY}:stable" \

--- a/.github/workflows/gwy-promote-stable.yaml
+++ b/.github/workflows/gwy-promote-stable.yaml
@@ -1,0 +1,31 @@
+name: gateway-promote-stable
+
+on:
+    workflow_dispatch:
+        inputs:
+            commit_sha:
+                description: 'Short commit SHA to promote (e.g. a1b2c3d)'
+                required: true
+                type: string
+
+permissions:
+    packages: write
+
+jobs:
+    gwy-promote:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Log in to ghcr.io
+              uses: docker/login-action@v4
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Promote dev-<sha> to stable
+              run: |
+                  SHA="${{ inputs.commit_sha }}"
+                  REGISTRY="ghcr.io/spectrumx/sds-gateway"
+                  docker buildx imagetools create \
+                      --tag "${REGISTRY}:stable" \
+                      "${REGISTRY}:dev-${SHA}"

--- a/.github/workflows/sdk-build-and-publish.yaml
+++ b/.github/workflows/sdk-build-and-publish.yaml
@@ -39,7 +39,7 @@ jobs:
 
             # https://github.com/astral-sh/setup-uv
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
               with:
                   # The version of uv to install
                   version: latest # optional, default is latest
@@ -147,7 +147,7 @@ jobs:
 
             # https://github.com/astral-sh/setup-uv
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
               with:
                   version: latest # optional, default is latest
                   # used to increase the rate limit when retrieving versions and downloading uv.

--- a/.github/workflows/sdk-build-and-publish.yaml
+++ b/.github/workflows/sdk-build-and-publish.yaml
@@ -29,7 +29,7 @@ jobs:
         steps:
             # https://github.com/actions/checkout
             - name: Checkout code
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
 
             # https://github.com/actions/setup-python
             - name: Set up Python
@@ -39,7 +39,7 @@ jobs:
 
             # https://github.com/astral-sh/setup-uv
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v8
               with:
                   # The version of uv to install
                   version: latest # optional, default is latest
@@ -100,7 +100,7 @@ jobs:
 
             - name: Store artifact
               # https://github.com/actions/upload-artifact?tab=readme-ov-file#inputs
-              uses: actions/upload-artifact@main
+              uses: actions/upload-artifact@v7
               with:
                   name: dist
                   path: ./sdk/dist
@@ -113,7 +113,7 @@ jobs:
         steps:
             - name: Download artifact for GH release
               # https://github.com/actions/download-artifact?tab=readme-ov-file#inputs
-              uses: actions/download-artifact@main
+              uses: actions/download-artifact@v8
               with:
                   name: dist
                   path: ./sdk/dist
@@ -121,7 +121,7 @@ jobs:
             - name: Automatic GitHub release
               # https://github.com/marketplace/actions/automatic-releases
               # generates a `@latest` release on github with automatic changelog
-              uses: "marvinpinto/action-automatic-releases@latest"
+              uses: "marvinpinto/action-automatic-releases@v1.2.1"
               with:
                   repo_token: "${{ secrets.GITHUB_TOKEN }}"
                   prerelease: false
@@ -140,14 +140,14 @@ jobs:
         steps:
             - name: Download artifact for PyPI deploy
               # https://github.com/actions/download-artifact?tab=readme-ov-file#inputs
-              uses: actions/download-artifact@main
+              uses: actions/download-artifact@v8
               with:
                   name: dist
                   path: ./sdk/dist
 
             # https://github.com/astral-sh/setup-uv
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v8
               with:
                   version: latest # optional, default is latest
                   # used to increase the rate limit when retrieving versions and downloading uv.

--- a/.github/workflows/sdk-code-quality.yaml
+++ b/.github/workflows/sdk-code-quality.yaml
@@ -44,7 +44,7 @@ jobs:
                   node-version: 24
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
               # https://github.com/marketplace/actions/astral-sh-setup-uv
 
             - name: Cache prek hooks
@@ -76,7 +76,7 @@ jobs:
             - uses: actions/checkout@v7
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
 
             - name: Install Python
               working-directory: ./sdk
@@ -115,7 +115,7 @@ jobs:
                   npm install -g rust-just
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
               # https://github.com/marketplace/actions/astral-sh-setup-uv
 
             - name: Run all tests

--- a/.github/workflows/sdk-code-quality.yaml
+++ b/.github/workflows/sdk-code-quality.yaml
@@ -35,7 +35,7 @@ jobs:
         env:
             UV_LINK_MODE: copy
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
 
             # this ubuntu-latest version ships node 18, which was causing issues
             # https://github.com/actions/setup-node#usage
@@ -44,12 +44,12 @@ jobs:
                   node-version: 24
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v8
               # https://github.com/marketplace/actions/astral-sh-setup-uv
 
             - name: Cache prek hooks
               id: cache-prek
-              uses: actions/cache@v5
+              uses: actions/cache@v6
               # https://github.com/actions/cache/blob/main/examples.md#python---pip
               with:
                   key: prek-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -73,10 +73,10 @@ jobs:
             UV_LINK_MODE: copy
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v8
 
             - name: Install Python
               working-directory: ./sdk
@@ -86,7 +86,7 @@ jobs:
               working-directory: ./sdk
               run: uv sync -p ${{ env.PYTHON_VERSION }} --frozen --dev
 
-            - uses: jakebailey/pyright-action@v2
+            - uses: jakebailey/pyright-action@v3
               # https://github.com/jakebailey/pyright-action#options
               with:
                   pylance-version: latest-release
@@ -106,7 +106,7 @@ jobs:
                 platform: [ubuntu-latest]
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
 
             - name: Install just on ubuntu
               if: matrix.platform == 'ubuntu-latest'
@@ -115,7 +115,7 @@ jobs:
                   npm install -g rust-just
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v8
               # https://github.com/marketplace/actions/astral-sh-setup-uv
 
             - name: Run all tests

--- a/.github/workflows/sdk-cross-platform-tests.yaml
+++ b/.github/workflows/sdk-cross-platform-tests.yaml
@@ -15,10 +15,10 @@ jobs:
                 platform: [ubuntu-latest, windows-latest, macos-latest]
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v7
+              uses: astral-sh/setup-uv@v8
               # https://github.com/marketplace/actions/astral-sh-setup-uv
 
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/sdk-cross-platform-tests.yaml
+++ b/.github/workflows/sdk-cross-platform-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             - uses: actions/checkout@v7
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
               # https://github.com/marketplace/actions/astral-sh-setup-uv
 
             - name: Set up Python ${{ matrix.python-version }}

--- a/gateway/compose.production.yaml
+++ b/gateway/compose.production.yaml
@@ -39,10 +39,7 @@ networks:
 
 services:
     sds-gateway-prod-app:
-        build:
-            context: .
-            dockerfile: ./compose/production/django/Dockerfile
-        image: sds-gateway-prod-app
+        image: ghcr.io/spectrumx/sds-gateway:${SDS_GATEWAY_TAG:-stable}
         container_name: sds-gateway-prod-app
         tty: true
         depends_on:
@@ -337,10 +334,7 @@ services:
     # ===================
     # Celery services for background tasks
     celery-worker:
-        build:
-            context: .
-            dockerfile: ./compose/production/django/Dockerfile
-        image: sds-gateway-prod-app
+        image: ghcr.io/spectrumx/sds-gateway:${SDS_GATEWAY_TAG:-stable}
         container_name: sds-gateway-prod-celery-worker
         tty: true
         depends_on:
@@ -398,10 +392,7 @@ services:
 
     celery-beat:
         # Celery Beat scheduler for periodic tasks
-        build:
-            context: .
-            dockerfile: ./compose/production/django/Dockerfile
-        image: sds-gateway-prod-app
+        image: ghcr.io/spectrumx/sds-gateway:${SDS_GATEWAY_TAG:-stable}
         container_name: sds-gateway-prod-celery-beat
         depends_on:
             sds-gateway-prod-app:
@@ -458,10 +449,7 @@ services:
 
     celery-flower:
         # Celery monitoring and administration tool
-        build:
-            context: .
-            dockerfile: ./compose/production/django/Dockerfile
-        image: sds-gateway-prod-app
+        image: ghcr.io/spectrumx/sds-gateway:${SDS_GATEWAY_TAG:-stable}
         container_name: sds-gateway-prod-celery-flower
         tty: true
         depends_on:


### PR DESCRIPTION
- Saves build time for QA and production deployments by pulling a pre-built image from GHCR
- Publishing Gateway images to GHCR
- Updated versions of GH actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production deploys now depend on ghcr image availability and tag discipline (`stable` / `SDS_GATEWAY_TAG`); mis-promotion or failed pushes could block or skew rollouts, though runtime code paths are unchanged.
> 
> **Overview**
> Adds **CI publishing** for the Gateway Django image to `ghcr.io/spectrumx/sds-gateway` after pre-commit and Django tests pass on pushes to `main`/`master` (or manual dispatch). Images get **`dev-<short-sha>`** tags plus **`dev`** on the default branch; build uses the production Dockerfile with GHA cache and `GIT_COMMIT` / `BUILD_ENVIRONMENT=production` build args.
> 
> Introduces a **manual `gateway-promote-stable` workflow** that retags an existing `dev-<sha>` image to **`stable`** via `docker buildx imagetools create` (no rebuild).
> 
> **Production compose** stops local `build` for the app and all Celery services; they now pull `ghcr.io/spectrumx/sds-gateway:${SDS_GATEWAY_TAG:-stable}` instead of `sds-gateway-prod-app`.
> 
> Across Gateway and SDK workflows, **GitHub Actions are bumped** (e.g. `checkout@v7`, `setup-uv@v8`, `cache@v6`, pinned upload/download-artifact and automatic-releases versions, `pyright-action@v3`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9dac499330005b53fb6ebbb9dca9520ad1a7db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->