### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,13 +55,22 @@ docker exec -e DJANGO_SUPERUSER_PASSWORD='<pw>' \
 Local auth uses django-allauth with email + password (email verification is off and
 self-registration is allowed), so you can also just sign up at `/accounts/login/`.
 
-### Known non-blocking caveat: nginx health
+### Known non-blocking caveats: container "unhealthy" markers
 
-The `sds-gateway-local-nginx` container reports `unhealthy`. This is only because its
-healthcheck runs `wget http://localhost/healthz`, which resolves to IPv6 `::1` while nginx
-listens on IPv4 `0.0.0.0:80`. nginx serves correctly (static files and `/healthz` return
-`200` over IPv4). This does not affect local development — the Django app is reached
-directly on port `8000`.
+Two containers can report `unhealthy` while functioning correctly:
+
+- `sds-gateway-local-nginx`: its healthcheck runs `wget http://localhost/healthz`, which
+  resolves to IPv6 `::1` while nginx listens on IPv4 `0.0.0.0:80`. nginx serves correctly
+  (static files and `/healthz` return `200` over IPv4). The Django app is reached directly
+  on port `8000`, so this does not affect local development.
+- `sds-gateway-local-celery-worker`: the `celery inspect ping` healthcheck can flap, but
+  the worker is functional — it actively receives and succeeds tasks (e.g. the periodic
+  `monitor_services_health` task), and `uv run celery -A config.celery_app inspect ping`
+  returns `OK`.
+
+Note the health-monitoring task reports `secondary-storage: down` locally; this is expected
+because SeaweedFS (the optional secondary store) is intentionally skipped — RustFS is the
+healthy primary store.
 
 ### Lint / test / build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This monorepo contains several components (`gateway`, `sdk`, `network`, `jupyter`,
+`seaweedfs`). The core product is the **Gateway** — a Django web app + REST API. The
+**SDK** (`spectrumx`) is the Python client library. Everything for the Gateway runs in
+Docker Compose; there is no top-level orchestrator, each component is driven from its own
+directory via `just` + Docker Compose. Standard recipes are documented in
+`gateway/README.md` and `gateway/justfile` (`just --list`); prefer those over duplicating
+commands here.
+
+### Docker daemon must be started manually
+
+There is no `systemd` in this environment, so Docker does not auto-start. Before running
+any Gateway/`just` command, start the daemon if it is not already running (it listens on
+the default socket, and the `ubuntu` user is in the `docker` group so `sudo` is not needed
+for the `docker` CLI):
+
+```bash
+pgrep dockerd >/dev/null || sudo dockerd >/tmp/dockerd.log 2>&1 &
+# if the socket is not group-accessible after a fresh start:
+sudo chmod 666 /var/run/docker.sock
+```
+
+### Running the Gateway stack (the end-to-end product)
+
+From `gateway/`, the local deploy builds all images and starts the stack. Skip SeaweedFS
+locally — RustFS is the primary S3 store for local/CI, and SeaweedFS is only an optional
+secondary store:
+
+```bash
+cd gateway
+SDS_SKIP_SFS=true ./scripts/deploy.sh local
+```
+
+The web app is served directly at <http://localhost:8000> (admin at `/admin`, API docs at
+`/api/latest/docs/`, webpack dev server at <http://localhost:3000>).
+
+`deploy.sh` is interactive by default in two places; make it non-interactive like this:
+
+- It prompts "Is this machine a production host?" on first run. `scripts/prod-hostnames.env`
+  is created before the prompt, so it is skipped on subsequent runs. To avoid it entirely,
+  ensure `scripts/prod-hostnames.env` exists and redirect stdin from `/dev/null`.
+- `createsuperuser` is interactive and is skipped when there is no TTY. Create a superuser
+  non-interactively against the running app container instead (the user model's
+  `USERNAME_FIELD` is `email`):
+
+```bash
+docker exec -e DJANGO_SUPERUSER_PASSWORD='<pw>' \
+  sds-gateway-local-app \
+  uv run python manage.py createsuperuser --noinput --email <email>
+```
+
+Local auth uses django-allauth with email + password (email verification is off and
+self-registration is allowed), so you can also just sign up at `/accounts/login/`.
+
+### Known non-blocking caveat: nginx health
+
+The `sds-gateway-local-nginx` container reports `unhealthy`. This is only because its
+healthcheck runs `wget http://localhost/healthz`, which resolves to IPv6 `::1` while nginx
+listens on IPv4 `0.0.0.0:80`. nginx serves correctly (static files and `/healthz` return
+`200` over IPv4). This does not affect local development — the Django app is reached
+directly on port `8000`.
+
+### Lint / test / build
+
+Run from `gateway/`:
+
+- Lint (all pre-commit hooks): `just pre-commit`
+- Python tests (pytest inside the app container): `just test-py`
+- JavaScript tests (jest inside the node container): `just test-js`
+- Everything: `just test`
+
+The host-side `uv` virtualenvs (in `gateway/.venv` and `sdk/.venv`) are used for lint
+tooling (ruff, deptry, pyrefly) and are refreshed by the startup update script. Note that
+the containers manage their own dependencies (synced on image build / container entrypoint);
+re-running a host `uv sync` does not update code already running inside containers — rebuild
+the relevant service (`just build <service>` / `just redeploy`) to pick up dependency
+changes there.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for this monorepo and validates it end-to-end against the core product (the **Gateway** Django web app + REST API). Adds an `AGENTS.md` with durable, non-obvious startup/run caveats for future agents. The only code change is the new `AGENTS.md`; all other setup is captured in the VM environment (system deps) and the startup update script (host `uv` deps).

## What was installed
- Docker Engine + Compose plugin (docker-in-docker with `fuse-overlayfs` storage driver, `containerd-snapshotter` disabled for Docker 29, `iptables-legacy`).
- `just`, `uv` (symlinked into `/usr/local/bin`), `postgresql-client`, and `libpq-dev`/`build-essential` (needed to build `psycopg[c]` in the host `uv` venv).
- Host `uv` virtualenvs for `gateway` (`--extra local`) and `sdk`.

## Update script (startup dependency refresh)
```
uv sync --project gateway --extra local --frozen
uv sync --project sdk --frozen
```

## Services / verification
The Gateway local stack was deployed via `SDS_SKIP_SFS=true ./scripts/deploy.sh local` (RustFS is the local primary S3 store; SeaweedFS is an optional secondary and is skipped locally). All required services came up: Django app, Postgres, Redis, OpenSearch, RustFS, Celery worker + beat, node/webpack, nginx.

| Check | Command | Result |
| --- | --- | --- |
| Lint | `just pre-commit` | ✅ all hooks pass |
| Python tests | `just test-py` | ✅ 593 passed |
| JS tests | `just test-js` | ✅ 607 passed |
| Run + hello-world | `SDS_SKIP_SFS=true ./scripts/deploy.sh local` | ✅ logged in, generated API key |

### Hello-world walkthrough
Logged in to the web UI at `http://localhost:8000` and generated an API key (the core Gateway↔SDK action).

[gateway_login_and_generate_api_key.mp4](https://cursor.com/agents/bc-d8a6e9db-16d4-4bba-9f00-6f7f23d35573/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgateway_login_and_generate_api_key.mp4)

[Logged-in API Keys page](https://cursor.com/agents/bc-d8a6e9db-16d4-4bba-9f00-6f7f23d35573/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgateway_logged_in.webp)
[Generated API key success page](https://cursor.com/agents/bc-d8a6e9db-16d4-4bba-9f00-6f7f23d35573/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgateway_api_key_generated.webp)

### Known non-blocking caveat
`sds-gateway-local-nginx` reports `unhealthy` only because its healthcheck `wget http://localhost/healthz` resolves to IPv6 `::1` while nginx listens on IPv4 `0.0.0.0:80`. nginx serves correctly over IPv4 and the app is reached directly on port `8000`. Documented in `AGENTS.md`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8a6e9db-16d4-4bba-9f00-6f7f23d35573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8a6e9db-16d4-4bba-9f00-6f7f23d35573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

