### PR TITLE
Displaying UUIDs on asset details

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,66 +1,69 @@
 {
-    "name": "sds_gateway",
-    "version": "0.0.1",
-    "devDependencies": {
-        "@babel/core": "^7.29.7",
-        "@babel/plugin-transform-runtime": "^7.29.7",
-        "@babel/preset-env": "^7.29.7",
-        "@biomejs/biome": "^1.9.4",
-        "@popperjs/core": "^2.11.8",
-        "autoprefixer": "^10.5.0",
-        "babel-jest": "^29.7.0",
-        "babel-loader": "^9.2.1",
-        "bootstrap": "^5.3.8",
-        "css-loader": "^6.11.0",
-        "fallow": "^2.89.0",
-        "jest": "^29.7.0",
-        "jest-environment-jsdom": "^29.7.0",
-        "mini-css-extract-plugin": "^2.10.2",
-        "node-sass-tilde-importer": "^1.0.2",
-        "pixrem": "^5.0.0",
-        "postcss": "^8.5.15",
-        "postcss-loader": "^8.2.1",
-        "postcss-preset-env": "^9.6.0",
-        "sass": "^1.100.0",
-        "sass-loader": "^14.2.1",
-        "webpack": "^5.107.2",
-        "webpack-bundle-tracker": "^3.2.4",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.2.4",
-        "webpack-merge": "^5.10.0"
-    },
-    "dependencies": {
-        "@babel/runtime": "^7.29.7"
-    },
-    "engines": {
-        "node": "24"
-    },
-    "devEngines": {
-        "runtime": {
-            "name": "node",
-            "version": "^24.0",
-            "onFail": "download"
-        }
-    },
-    "browserslist": ["last 2 versions"],
-    "babel": {
-        "presets": ["@babel/preset-env"],
-        "plugins": ["@babel/plugin-transform-runtime"]
-    },
-    "parser": "babel-eslint",
-    "parserOptions": {
-        "sourceType": "module",
-        "allowImportExportEverywhere": true
-    },
-    "scripts": {
-        "dev": "webpack --config webpack/dev.config.js; webpack serve --config webpack/dev.config.js",
-        "build": "webpack --config webpack/prod.config.js",
-        "test": "jest --config sds_gateway/static/js/tests-config/jest.config.js",
-        "test:watch": "jest --config sds_gateway/static/js/tests-config/jest.config.js --watch",
-        "test:coverage": "jest --config sds_gateway/static/js/tests-config/jest.config.js --coverage",
-        "test:ci": "jest --config sds_gateway/static/js/tests-config/jest.config.js --ci --coverage --watchAll=false",
-        "fallow": "fallow --summary",
-        "fallow:static-js": "node scripts/fallow-static-js-dead-code.cjs"
-    },
-    "packageManager": "pnpm@11.5.2"
+  "name": "sds_gateway",
+  "version": "0.0.1",
+  "devDependencies": {
+    "@babel/core": "^7.29.7",
+    "@babel/plugin-transform-runtime": "^7.29.7",
+    "@babel/preset-env": "^7.29.7",
+    "@biomejs/biome": "^1.9.4",
+    "@popperjs/core": "^2.11.8",
+    "autoprefixer": "^10.5.0",
+    "babel-jest": "^29.7.0",
+    "babel-loader": "^9.2.1",
+    "bootstrap": "^5.3.8",
+    "css-loader": "^6.11.0",
+    "fallow": "^2.89.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "mini-css-extract-plugin": "^2.10.2",
+    "node-sass-tilde-importer": "^1.0.2",
+    "pixrem": "^5.0.0",
+    "postcss": "^8.5.15",
+    "postcss-loader": "^8.2.1",
+    "postcss-preset-env": "^9.6.0",
+    "sass": "^1.100.0",
+    "sass-loader": "^14.2.1",
+    "webpack": "^5.107.2",
+    "webpack-bundle-tracker": "^3.2.4",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.2.4",
+    "webpack-merge": "^5.10.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.29.7"
+  },
+  "engines": {
+    "node": "24"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^24.0",
+      "onFail": "download"
+    }
+  },
+  "browserslist": ["last 2 versions"],
+  "babel": {
+    "presets": ["@babel/preset-env"],
+    "plugins": ["@babel/plugin-transform-runtime"]
+  },
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "sourceType": "module",
+    "allowImportExportEverywhere": true
+  },
+  "scripts": {
+    "dev": "webpack --config webpack/dev.config.js; webpack serve --config webpack/dev.config.js",
+    "build": "webpack --config webpack/prod.config.js",
+    "test": "jest --config sds_gateway/static/js/tests-config/jest.config.js",
+    "test:watch": "jest --config sds_gateway/static/js/tests-config/jest.config.js --watch",
+    "test:coverage": "jest --config sds_gateway/static/js/tests-config/jest.config.js --coverage",
+    "test:ci": "jest --config sds_gateway/static/js/tests-config/jest.config.js --ci --coverage --watchAll=false",
+    "fallow": "fallow --summary",
+    "fallow:static-js": "node scripts/fallow-static-js-dead-code.cjs"
+  },
+  "packageManager": "pnpm@11.5.2",
+  "workspaces": [
+    "."
+  ]
 }

--- a/gateway/sds_gateway/static/js/constants/__tests__/detailsModalConfig.test.js
+++ b/gateway/sds_gateway/static/js/constants/__tests__/detailsModalConfig.test.js
@@ -67,6 +67,17 @@ describe("detailsModalConfig", () => {
         )
     })
 
+    test("capture afterInject wires attachUuidCopyButton on modal", () => {
+        const attachUuidCopyButton = jest.fn()
+        window.DetailsActionManager = { attachUuidCopyButton }
+        window.CaptureDetailsModalBehavior = {
+            afterInject: jest.fn(),
+        }
+        const modal = document.getElementById("asset-details-modal")
+        registry().capture.afterInject({ modal, meta: { uuid: "cap-42" } })
+        expect(attachUuidCopyButton).toHaveBeenCalledWith(modal, "cap-42")
+    })
+
     test("dataset afterInject wires uuid copy on modal", () => {
         const attachUuidCopyButton = jest.fn()
         window.DetailsActionManager = { attachUuidCopyButton }

--- a/gateway/sds_gateway/static/js/constants/detailsModalConfig.js
+++ b/gateway/sds_gateway/static/js/constants/detailsModalConfig.js
@@ -43,6 +43,12 @@
             if (window.CaptureDetailsModalBehavior?.afterInject) {
                 window.CaptureDetailsModalBehavior.afterInject(ctx)
             }
+            if (window.DetailsActionManager?.attachUuidCopyButton) {
+                window.DetailsActionManager.attachUuidCopyButton(
+                    ctx.modal,
+                    ctx.meta?.uuid,
+                )
+            }
         },
         loadingTitle: "Loading capture details...",
     }

--- a/gateway/sds_gateway/templates/users/capture_list.html
+++ b/gateway/sds_gateway/templates/users/capture_list.html
@@ -276,6 +276,7 @@
     <script src="{% static 'js/actions/CaptureReindexingManager.js' %}"></script>
     <script src="{% static 'js/actions/AssetDeletionManager.js' %}"></script>
     <script src="{% static 'js/actions/CaptureListSelectionManager.js' %}"></script>
+    <script src="{% static 'js/actions/DetailsActionManager.js' %}"></script>
     <script src="{% static 'js/constants/detailsModalConfig.js' %}"></script>
     <script src="{% static 'js/visualizations/visualizationModal.js' %}"></script>
     <script src="{% static 'js/constants/FileListConfig.js' %}"></script>

--- a/gateway/sds_gateway/templates/users/components/capture_details_modal_body.html
+++ b/gateway/sds_gateway/templates/users/components/capture_details_modal_body.html
@@ -173,3 +173,17 @@ Capture details modal body — rendered server-side for ModalManager injection.
     </div>
 {% endif %}
 <div class="mt-4">{% include "users/components/capture_files_summary_fragment.html" %}</div>
+<hr class="my-3" />
+<div class="d-flex align-items-center text-muted small">
+    <i class="bi bi-code-slash me-2"></i>
+    <span>
+        <a href="https://sds.crc.nd.edu/sdk/api/captures/"
+           target="_blank"
+           rel="noopener"
+           class="text-decoration-none">SDK Captures API</a>
+        · <a href="https://sds.crc.nd.edu/sdk/common-workflows/capture-uploads/"
+    target="_blank"
+    rel="noopener"
+    class="text-decoration-none">Upload via SDK</a>
+    </span>
+</div>

--- a/gateway/sds_gateway/templates/users/components/capture_details_modal_body.html
+++ b/gateway/sds_gateway/templates/users/components/capture_details_modal_body.html
@@ -62,6 +62,19 @@ Capture details modal body — rendered server-side for ModalManager injection.
         <span class="fw-medium text-muted">{{ channel_label }}:</span>
         <span class="ms-2">{{ channel_value }}</span>
     </div>
+    <div class="mb-2">
+        <span class="fw-medium text-muted">UUID:</span>
+        <code class="ms-2">{{ capture_uuid }}</code>
+        <button type="button"
+                class="copy-uuid-btn btn btn-link p-0 border-0 ms-2"
+                data-bs-toggle="tooltip"
+                data-bs-placement="top"
+                title="Copy Capture UUID"
+                data-uuid="{{ capture_uuid }}"
+                aria-label="Copy capture UUID">
+            <i class="bi bi-clipboard"></i> Copy UUID
+        </button>
+    </div>
 </div>
 <div class="mb-4">
     <div class="d-flex align-items-center mb-3">

--- a/gateway/sds_gateway/templates/users/components/dataset_details_modal_body.html
+++ b/gateway/sds_gateway/templates/users/components/dataset_details_modal_body.html
@@ -16,16 +16,20 @@
                                 <label class="fw-bold text-muted mb-0">Dataset Name:</label>
                                 <div class="d-flex align-items-center gap-2">
                                     <p class="mb-0 dataset-details-name">{{ dataset.name }} (v{{ dataset.version }})</p>
-                                    <button type="button"
-                                            class="copy-uuid-btn btn btn-link p-0 border-0"
-                                            data-bs-toggle="tooltip"
-                                            data-bs-placement="top"
-                                            title="Copy Dataset UUID"
-                                            data-uuid="{{ dataset_uuid }}"
-                                            aria-label="Copy dataset UUID">
-                                        <i class="bi bi-clipboard"></i>
-                                    </button>
                                 </div>
+                            </div>
+                            <div class="mb-3">
+                                <label class="fw-bold text-muted">UUID:</label>
+                                <code class="ms-2">{{ dataset_uuid }}</code>
+                                <button type="button"
+                                        class="copy-uuid-btn btn btn-link p-0 border-0 ms-2"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="Copy Dataset UUID"
+                                        data-uuid="{{ dataset_uuid }}"
+                                        aria-label="Copy dataset UUID">
+                                    <i class="bi bi-clipboard"></i> Copy UUID
+                                </button>
                             </div>
                             <div class="mb-3">
                                 <label class="fw-bold text-muted">Author(s):</label>

--- a/gateway/sds_gateway/templates/users/components/dataset_details_modal_body.html
+++ b/gateway/sds_gateway/templates/users/components/dataset_details_modal_body.html
@@ -147,4 +147,18 @@
         </div>
     </div>
 </div>
+<hr class="my-3" />
+<div class="d-flex align-items-center text-muted small">
+    <i class="bi bi-code-slash me-2"></i>
+    <span>
+        <a href="https://sds.crc.nd.edu/sdk/api/datasets/"
+           target="_blank"
+           rel="noopener"
+           class="text-decoration-none">SDK Datasets API</a>
+        · <a href="https://sds.crc.nd.edu/sdk/common-workflows/dataset-downloads/"
+    target="_blank"
+    rel="noopener"
+    class="text-decoration-none">Download via SDK</a>
+    </span>
+</div>
 </div>

--- a/gateway/sds_gateway/templates/users/file_detail.html
+++ b/gateway/sds_gateway/templates/users/file_detail.html
@@ -35,7 +35,18 @@
                             </strong>
                         </div>
                         <div class="col-9">
-                            {% if key == "directory" or key == "sum_blake3" or key == "uuid" %}
+                            {% if key == "uuid" %}
+                                <code>{{ value }}</code>
+                                <button type="button"
+                                        class="copy-uuid-btn btn btn-link p-0 border-0 ms-2"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="Copy UUID"
+                                        data-uuid="{{ value }}"
+                                        aria-label="Copy file UUID">
+                                    <i class="bi bi-clipboard"></i> Copy UUID
+                                </button>
+                            {% elif key == "directory" or key == "sum_blake3" %}
                                 <code>{{ value }}</code>
                             {% elif key == "owner" %}
                                 {{ request.user.name }}
@@ -62,3 +73,14 @@
         {% endfor %}
     </ul>
 {% endblock content %}
+{% block javascript %}
+    <script src="{% static 'js/actions/DetailsActionManager.js' %}"></script>
+    <script>
+        (function() {
+            var btn = document.querySelector(".copy-uuid-btn");
+            if (btn && btn.dataset.uuid) {
+                DetailsActionManager.attachUuidCopyButton(document, btn.dataset.uuid);
+            }
+        })();
+    </script>
+{% endblock javascript %}

--- a/gateway/sds_gateway/templates/users/file_detail.html
+++ b/gateway/sds_gateway/templates/users/file_detail.html
@@ -10,6 +10,15 @@
     <div>
         <a href="{% url 'users:files' %}?page={{ returning_page|default:1 }}"
            class="btn btn-primary mt-3">Back to File List</a>
+        <div class="alert alert-info d-flex align-items-center my-3" role="alert">
+            <i class="bi bi-code-slash me-2"></i>
+            <div>
+                <a href="https://sds.crc.nd.edu/sdk/api/sds_files/"
+                   class="alert-link"
+                   target="_blank"
+                   rel="noopener">Manage files via the Python SDK</a>.
+            </div>
+        </div>
         <h2>
             File <code>{{ file.name }}</code>
         </h2>

--- a/gateway/sds_gateway/templates/users/file_detail.html
+++ b/gateway/sds_gateway/templates/users/file_detail.html
@@ -83,13 +83,14 @@
     </ul>
 {% endblock content %}
 {% block javascript %}
+    {{ block.super }}
     <script src="{% static 'js/actions/DetailsActionManager.js' %}"></script>
     <script>
-        (function() {
+        document.addEventListener("DOMContentLoaded", function() {
             var btn = document.querySelector(".copy-uuid-btn");
             if (btn && btn.dataset.uuid) {
                 DetailsActionManager.attachUuidCopyButton(document, btn.dataset.uuid);
             }
-        })();
+        });
     </script>
 {% endblock javascript %}

--- a/gateway/sds_gateway/templates/users/files.html
+++ b/gateway/sds_gateway/templates/users/files.html
@@ -38,8 +38,8 @@
     <div class="content-wrapper">
         <div class="main-content-area">
             <div class="container mt-4">
-                <h1 class="page-title mb-3">Files</h1>
                 <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h1 class="page-title mb-3">Files</h1>
                     <div class="dropdown">
                         <button class="btn btn-primary dropdown-toggle"
                                 type="button"
@@ -315,6 +315,7 @@
 {% endblock content %}
 {% block javascript %}
     {{ block.super }}
+    <script src="{% static 'js/actions/DetailsActionManager.js' %}"></script>
     <script src="{% static 'js/constants/detailsModalConfig.js' %}"></script>
     <script src="{% static 'js/share/UserSearchDropdown.js' %}"></script>
     <script src="{% static 'js/actions/ShareActionManager.js' %}"></script>

--- a/gateway/sds_gateway/templates/users/files.html
+++ b/gateway/sds_gateway/templates/users/files.html
@@ -38,8 +38,8 @@
     <div class="content-wrapper">
         <div class="main-content-area">
             <div class="container mt-4">
+                <h1 class="page-title mb-3">Files</h1>
                 <div class="d-flex justify-content-between align-items-center mb-4">
-                    <h1 class="page-title">Files</h1>
                     <div class="dropdown">
                         <button class="btn btn-primary dropdown-toggle"
                                 type="button"
@@ -64,6 +64,18 @@
                                    data-bs-toggle="modal"
                                    data-bs-target="#uploadFileModal">
                                     <i class="material-icons file-icon">description</i> Other Files
+                                </a>
+                            </li>
+                            <li>
+                                <hr class="dropdown-divider" />
+                            </li>
+                            <li>
+                                <a class="dropdown-item"
+                                   href="https://sds.crc.nd.edu/sdk/getting-started/"
+                                   target="_blank"
+                                   rel="noopener">
+                                    <i class="bi bi-code-slash"></i> SDK Setup Guide
+                                    <span class="text-body-secondary fst-italic">Python</span>
                                 </a>
                             </li>
                         </ul>

--- a/gateway/sds_gateway/templates/users/generate_api_key_form.html
+++ b/gateway/sds_gateway/templates/users/generate_api_key_form.html
@@ -17,6 +17,20 @@
                         <i class="bi bi-key"></i> View API Keys
                     </a>
                 </div>
+                <!-- SDK Documentation Banner -->
+                <div class="alert alert-info d-flex align-items-center mb-3" role="alert">
+                    <i class="bi bi-code-slash me-2"></i>
+                    <div>
+                        <a href="https://sds.crc.nd.edu/sdk/getting-started/"
+                           class="alert-link"
+                           target="_blank"
+                           rel="noopener">Use your API key with the Python SDK</a>
+                        — see the <a href="https://sds.crc.nd.edu/sdk/faq/#how-to-generate-a-secret-token"
+    class="alert-link"
+    target="_blank"
+    rel="noopener">FAQ for token generation</a>.
+                    </div>
+                </div>
                 <hr />
                 <div class="col-lg-12 mx-auto">
                     <form method="post" action="{% url 'users:view_api_key' %}">

--- a/gateway/sds_gateway/templates/users/new_api_key.html
+++ b/gateway/sds_gateway/templates/users/new_api_key.html
@@ -21,6 +21,15 @@
                         <pre class="api-key-text"><strong>{{ api_key }}</strong></pre>
                     </div>
                     <p class="text-danger mt-3">Keep this key safe and secure. You will not be able to view it again.</p>
+                    <div class="alert alert-info d-flex align-items-center my-3" role="alert">
+                        <i class="bi bi-code-slash me-2"></i>
+                        <div>
+                            <a href="https://sds.crc.nd.edu/sdk/getting-started/"
+                               class="alert-link"
+                               target="_blank"
+                               rel="noopener">Next: Set up the Python SDK with this key</a>.
+                        </div>
+                    </div>
                     <p>
                         <button type="button"
                                 onclick="window.location.href='{% url 'users:view_api_key' %}'"

--- a/gateway/sds_gateway/templates/users/partials/upload_capture_modal.html
+++ b/gateway/sds_gateway/templates/users/partials/upload_capture_modal.html
@@ -18,6 +18,16 @@
                             aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
+                    <div class="alert alert-info d-flex align-items-center small mb-3"
+                         role="alert">
+                        <i class="bi bi-code-slash me-2"></i>
+                        <div>
+                            Prefer Python? <a href="https://sds.crc.nd.edu/sdk/common-workflows/capture-uploads/"
+    target="_blank"
+    rel="noopener"
+    class="alert-link">Upload captures via the SDK</a>
+                        </div>
+                    </div>
                     <label for="captureFileInput" class="form-label">Select a folder to upload</label>
                     <input type="file"
                            id="captureFileInput"

--- a/gateway/sds_gateway/templates/users/published_datasets_list.html
+++ b/gateway/sds_gateway/templates/users/published_datasets_list.html
@@ -20,6 +20,16 @@
         <div class="main-content-area">
             <div class="container mt-4">
                 <h1 class="page-title mb-4">Search Published Datasets</h1>
+                <!-- SDK Documentation Banner -->
+                <div class="alert alert-info d-flex align-items-center mb-3" role="alert">
+                    <i class="bi bi-code-slash me-2"></i>
+                    <div>
+                        <a href="https://sds.crc.nd.edu/sdk/common-workflows/dataset-downloads/"
+                           class="alert-link"
+                           target="_blank"
+                           rel="noopener">Download datasets programmatically with the Python SDK</a>.
+                    </div>
+                </div>
                 <!-- Search Form -->
                 {% include "users/partials/search_published_datasets_tab.html" %}
             </div>

--- a/gateway/sds_gateway/templates/users/user_api_key.html
+++ b/gateway/sds_gateway/templates/users/user_api_key.html
@@ -22,6 +22,16 @@
                         <i class="bi bi-plus-lg"></i> Generate API Key
                     </a>
                 </div>
+                <!-- SDK Documentation Banner -->
+                <div class="alert alert-info d-flex align-items-center mb-3" role="alert">
+                    <i class="bi bi-code-slash me-2"></i>
+                    <div>
+                        <a href="https://sds.crc.nd.edu/sdk/getting-started/"
+                           class="alert-link"
+                           target="_blank"
+                           rel="noopener">Use your API key with the Python SDK</a>.
+                    </div>
+                </div>
                 <hr />
                 <div id="dynamic-table-container" class="table-and-pagination">
                     <div class="table-container">


### PR DESCRIPTION
[SFDS-297](https://crc-dev.atlassian.net/browse/SFDS-297)

Changes to improve SDK usability from the website.

- UUIDs to datasets and capture details;
- Added relevant SDK docs links to multiple pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template and small JS wiring only; no auth, data, or API behavior changes. Risk is limited to copy-button wiring and extra external doc links.
> 
> **Overview**
> Makes it easier to use the Python SDK from the website by showing **copyable UUIDs** and linking to SDK docs on the relevant screens.
> 
> Capture and dataset details modals now display the UUID with a Copy UUID control (dataset copy moved off the name row). Capture `afterInject` wires the existing `attachUuidCopyButton` helper. File detail does the same for the file UUID.
> 
> Info banners and footer links point to getting started, captures/datasets/files APIs, and upload/download workflows on files, API key, published datasets, and upload-capture pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2f3353b6d6364ddcfecdf1ae30d997e660049c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->