### PR TITLE
Fix Allow any valid user access to public Dataset through SDK

### DIFF
--- a/gateway/sds_gateway/api_methods/models.py
+++ b/gateway/sds_gateway/api_methods/models.py
@@ -1458,7 +1458,9 @@ class UserSharePermission(BaseModel):
         # if we get to here then check if the item is public
         if item_type in item_models:
             model_class = item_models[ItemType(item_type)]
-            if model_class.objects.filter(uuid=item_uuid, is_public=True).exists():
+            if model_class.objects.filter(
+                uuid=item_uuid, is_public=True, is_deleted=False
+            ).exists():
                 return PermissionLevel.VIEWER
 
         return None

--- a/gateway/sds_gateway/api_methods/models.py
+++ b/gateway/sds_gateway/api_methods/models.py
@@ -1458,7 +1458,7 @@ class UserSharePermission(BaseModel):
         # if we get to here then check if the item is public
         if item_type in item_models:
             model_class = item_models[ItemType(item_type)]
-            if model_class.objects.filter(uuid=item_uuid).exists():
+            if model_class.objects.filter(uuid=item_uuid, is_public=True).exists():
                 return PermissionLevel.VIEWER
 
         return None

--- a/gateway/sds_gateway/api_methods/models.py
+++ b/gateway/sds_gateway/api_methods/models.py
@@ -1455,6 +1455,12 @@ class UserSharePermission(BaseModel):
         if permission:
             return permission.permission_level
 
+        # if we get to here then check if the item is public
+        if item_type in item_models:
+            model_class = item_models[ItemType(item_type)]
+            if model_class.objects.filter(uuid=item_uuid).exists():
+                return PermissionLevel.VIEWER
+
         return None
 
     @classmethod

--- a/gateway/sds_gateway/api_methods/utils/asset_access_control.py
+++ b/gateway/sds_gateway/api_methods/utils/asset_access_control.py
@@ -153,6 +153,7 @@ def get_accessible_files_queryset(user):
                 |
                 # Capture directly shared with user
                 Q(captures__uuid__in=captures_shared_with_user)
+                | Q(captures__is_public=True)
                 |
                 # Capture part of dataset that is shared with user (via M2M)
                 Q(
@@ -164,6 +165,7 @@ def get_accessible_files_queryset(user):
                     |
                     # Dataset directly shared with user
                     Q(captures__datasets__uuid__in=datasets_shared_with_user)
+                    | Q(captures__datasets__is_public=True)
                 )
             )
         )
@@ -202,6 +204,7 @@ def get_accessible_files_queryset(user):
                 |
                 # Dataset directly shared with user
                 Q(datasets__uuid__in=datasets_shared_with_user)
+                | Q(datasets__is_public=True)
             )
         )
         |
@@ -268,6 +271,7 @@ def get_accessible_captures_queryset(user):
                 |
                 # Dataset directly shared with user
                 Q(datasets__uuid__in=datasets_shared_with_user)
+                | Q(datasets__is_public=True)
             )
         )
         |

--- a/gateway/sds_gateway/api_methods/utils/asset_access_control.py
+++ b/gateway/sds_gateway/api_methods/utils/asset_access_control.py
@@ -77,7 +77,7 @@ def user_has_access_to_file(user, file: File) -> bool:
 
     # Check if file's captures are accessible (directly shared, owned by user)
     user_has_access_to_capture = any(
-        capture.owner == user or capture.uuid in shared_captures
+        capture.owner == user or capture.uuid in shared_captures or capture.is_public
         for capture in file_captures
     )
 
@@ -88,7 +88,9 @@ def user_has_access_to_file(user, file: File) -> bool:
                 capture, include_deleted=False
             )
             if any(
-                dataset.owner == user or dataset.uuid in shared_datasets
+                dataset.owner == user
+                or dataset.uuid in shared_datasets
+                or dataset.is_public
                 for dataset in capture_datasets
             ):
                 user_has_access_to_capture = True
@@ -97,7 +99,7 @@ def user_has_access_to_file(user, file: File) -> bool:
     # Use centralized function to get datasets (handles both M2M and FK)
     file_datasets = relationship_utils.get_file_datasets(file, include_deleted=False)
     user_has_access_to_dataset = any(
-        dataset.owner == user or dataset.uuid in shared_datasets
+        dataset.owner == user or dataset.uuid in shared_datasets or dataset.is_public
         for dataset in file_datasets
     )
 

--- a/gateway/sds_gateway/api_methods/utils/asset_access_control.py
+++ b/gateway/sds_gateway/api_methods/utils/asset_access_control.py
@@ -42,7 +42,7 @@ def user_has_access_to_capture(user, capture: Capture) -> bool:
 
     # Check if any dataset is owned by user or in shared_datasets
     user_has_access_to_dataset = any(
-        dataset.owner == user or dataset.uuid in shared_datasets
+        dataset.owner == user or dataset.uuid in shared_datasets or dataset.is_public
         for dataset in capture_datasets
     )
 


### PR DESCRIPTION
[SFDS-320](https://crc-dev.atlassian.net/browse/SFDS-320)
Fix permission issues trying to access assets of public datasets

- If a Dataset is public then allow a valid user to have Viewer permissions to download through SDK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Widens authorization: any logged-in user can view/download assets on public datasets and captures. Incomplete coverage of deprecated FK query paths could also leave access inconsistent.
> 
> **Overview**
> Authenticated users now get **viewer** access to public datasets and captures (and their nested files/captures) without an explicit share, so SDK downloads of public dataset assets work.
> 
> `UserSharePermission.get_user_permission_level` falls back to `PermissionLevel.VIEWER` when the item is public and not deleted. Capture/file access helpers and the accessible-files/captures querysets treat `is_public` like ownership or a share on M2M relationships (deprecated FK paths are unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7aaf7d40ecad9f53744f2b062f0f7b82e07d43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->